### PR TITLE
Fixing CRAIL-4 JIRA ticket

### DIFF
--- a/client/src/main/java/org/apache/crail/CrailBufferedInputStream.java
+++ b/client/src/main/java/org/apache/crail/CrailBufferedInputStream.java
@@ -249,7 +249,7 @@ public abstract class CrailBufferedInputStream extends InputStream {
 		}
 	}
 	
-	public final double readLong() throws Exception {
+	public final long readLong() throws Exception {
 		CrailBuffer slice = getSlice(true);
 		if (slice == null){
 			throw new EOFException();
@@ -268,7 +268,7 @@ public abstract class CrailBufferedInputStream extends InputStream {
 		}
 	}
 	
-	public final double readShort() throws Exception {
+	public final short readShort() throws Exception {
 		CrailBuffer slice = getSlice(true);
 		if (slice == null){
 			throw new EOFException();


### PR DESCRIPTION
readShort and readLong functions by did not return
the expected types. Now that is fixed in the function
signature.

https://issues.apache.org/jira/projects/CRAIL/issues/CRAIL-4