### PR TITLE
Applications can now choose on a per node basis (files, directories,

### DIFF
--- a/client/src/main/java/org/apache/crail/CrailStore.java
+++ b/client/src/main/java/org/apache/crail/CrailStore.java
@@ -33,7 +33,7 @@ public abstract class CrailStore {
 	private static AtomicLong referenceCounter = new AtomicLong(0);
 	private static CrailStore instance = null;
 	
-	public abstract Upcoming<CrailNode> create(String path, CrailNodeType type, CrailStorageClass storageClass, CrailLocationClass locationClass) throws Exception;
+	public abstract Upcoming<CrailNode> create(String path, CrailNodeType type, CrailStorageClass storageClass, CrailLocationClass locationClass, boolean enumerable) throws Exception;
 	public abstract Upcoming<CrailNode> lookup(String path) throws Exception;
 	public abstract Upcoming<CrailNode> rename(String srcPath, String dstPath) throws Exception;
 	public abstract Upcoming<CrailNode> delete(String path, boolean recursive) throws Exception;

--- a/client/src/main/java/org/apache/crail/core/CoreDataStore.java
+++ b/client/src/main/java/org/apache/crail/core/CoreDataStore.java
@@ -162,14 +162,14 @@ public class CoreDataStore extends CrailStore {
 		statistics.addProvider(datanodeEndpointCache);
 	}
 	
-	public Upcoming<CrailNode> create(String path, CrailNodeType type, CrailStorageClass storageClass, CrailLocationClass locationClass) throws Exception {
+	public Upcoming<CrailNode> create(String path, CrailNodeType type, CrailStorageClass storageClass, CrailLocationClass locationClass, boolean enumerable) throws Exception {
 		FileName name = new FileName(path);
 		
 		if (CrailConstants.DEBUG){
 			LOG.info("createNode: name " + path + ", type " + type + ", storageAffinity " + storageClass + ", locationAffinity " + locationClass);
 		}
 
-		RpcFuture<RpcCreateFile> fileRes = rpcConnection.createFile(name, type, storageClass.value(), locationClass.value());
+		RpcFuture<RpcCreateFile> fileRes = rpcConnection.createFile(name, type, storageClass.value(), locationClass.value(), enumerable);
 		return new CreateNodeFuture(this, path, type, fileRes);
 	}	
 	

--- a/client/src/main/java/org/apache/crail/metadata/FileInfo.java
+++ b/client/src/main/java/org/apache/crail/metadata/FileInfo.java
@@ -30,6 +30,9 @@ import org.apache.crail.conf.CrailConstants;
 public class FileInfo {
 	public static final int CSIZE = 44;
 	
+	public static final long ENUMERABLE = -1;
+	public static final long NOT_ENUMERABLE = -2;
+	
 	private long fd;
 	protected AtomicLong capacity;
 	private CrailNodeType type;
@@ -38,13 +41,13 @@ public class FileInfo {
 	private long modificationTime;
 	
 	public FileInfo(){
-		this(-1, CrailNodeType.DATAFILE);
+		this(-1, CrailNodeType.DATAFILE, true);
 	}
 	
-	protected FileInfo(long fd, CrailNodeType type){
+	protected FileInfo(long fd, CrailNodeType type, boolean enumerable){
 		this.fd = fd;
 		this.type = type;
-		this.dirOffset = -1;
+		this.dirOffset = enumerable ? ENUMERABLE : NOT_ENUMERABLE;
 		this.capacity = new AtomicLong(0);
 		this.token = 0;
 		this.modificationTime = 0;
@@ -155,5 +158,9 @@ public class FileInfo {
 
 	public void setToken(long value) {
 		this.token = value;
+	}
+	
+	public boolean isEnumerable() {
+		return dirOffset > -2;
 	}
 }

--- a/client/src/main/java/org/apache/crail/rpc/RpcConnection.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcConnection.java
@@ -29,7 +29,7 @@ import org.apache.crail.metadata.FileName;
 
 public interface RpcConnection {
 	public abstract RpcFuture<RpcCreateFile> createFile(
-			FileName filename, CrailNodeType type, int storageClass, int locationClass) throws IOException;
+			FileName filename, CrailNodeType type, int storageClass, int locationClass, boolean enumerable) throws IOException;
 
 	public abstract RpcFuture<RpcGetFile> getFile(FileName filename,
 			boolean writeable) throws IOException;

--- a/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
@@ -48,11 +48,11 @@ public class RpcDispatcher implements RpcConnection {
 
 	@Override
 	public RpcFuture<RpcCreateFile> createFile(FileName filename,
-			CrailNodeType type, int storageClass, int locationClass)
+			CrailNodeType type, int storageClass, int locationClass, boolean enumerable)
 			throws IOException {
 		int index = computeIndex(filename.getComponent(0));
 //		LOG.info("issuing create file for filename [" + filename.toString() + "], on index " + index);
-		return connections[index].createFile(filename, type, storageClass, locationClass);
+		return connections[index].createFile(filename, type, storageClass, locationClass, enumerable);
 	}
 
 	@Override

--- a/client/src/main/java/org/apache/crail/tools/CrailFsck.java
+++ b/client/src/main/java/org/apache/crail/tools/CrailFsck.java
@@ -133,7 +133,7 @@ public class CrailFsck {
 		System.out.println("createDirectory, filename " + filename + ", storageClass " + storageClass + ", locationClass " + locationClass);
 		CrailConfiguration conf = new CrailConfiguration();
 		CrailStore fs = CrailStore.newInstance(conf);
-		fs.create(filename, CrailNodeType.DIRECTORY, CrailStorageClass.get(storageClass), CrailLocationClass.get(locationClass)).get().syncDir();
+		fs.create(filename, CrailNodeType.DIRECTORY, CrailStorageClass.get(storageClass), CrailLocationClass.get(locationClass), true).get().syncDir();
 		fs.close();
 	}	
 	

--- a/client/src/test/java/org/apache/crail/ClientTest.java
+++ b/client/src/test/java/org/apache/crail/ClientTest.java
@@ -49,7 +49,7 @@ public class ClientTest {
 	public void init() throws Exception {
 		CrailConfiguration conf = new CrailConfiguration();
 		fs = CrailStore.newInstance(conf);
-		fs.create(basePath, CrailNodeType.DIRECTORY, CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT).get();
+		fs.create(basePath, CrailNodeType.DIRECTORY, CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT, true).get();
 	}
 
 	@After
@@ -60,14 +60,14 @@ public class ClientTest {
 	@Test
 	public void testCreateFile() throws Exception {
 		String filename = basePath + "/fooCreate"; 
-		fs.create(filename,  CrailNodeType.DATAFILE, CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT).get();
+		fs.create(filename,  CrailNodeType.DATAFILE, CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT, true).get();
 		fs.lookup(filename).get().asFile();
 	}
 
 	@Test
 	public void testDeleteFile() throws Exception {
 		String filename = basePath + "/fooDelete"; 
-		fs.create(filename, CrailNodeType.DATAFILE, CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT).get();
+		fs.create(filename, CrailNodeType.DATAFILE, CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT, true).get();
 		fs.delete(filename, false).get();
 		Assert.assertNull(fs.lookup(filename).get());
 	}
@@ -75,7 +75,7 @@ public class ClientTest {
 	@Test
 	public void testRenameFile() throws Exception {
 		String srcname = basePath + "/fooRename";
-		fs.create(srcname, CrailNodeType.DATAFILE, CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT).get();
+		fs.create(srcname, CrailNodeType.DATAFILE, CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT, true).get();
 		String dstname = basePath + "/barRename";
 		fs.rename(srcname, dstname).get();
 		Assert.assertNull(fs.lookup(srcname).get());
@@ -90,7 +90,7 @@ public class ClientTest {
 	@Test
 	public void testCreateDirectory() throws Exception {
 		String filename = basePath + "/fooDir";
-		fs.create(filename, CrailNodeType.DIRECTORY, CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT).get();
+		fs.create(filename, CrailNodeType.DIRECTORY, CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT, true).get();
 		fs.lookup(filename).get().asDirectory();
 	}
 
@@ -124,7 +124,7 @@ public class ClientTest {
 				position + ", length = " + length + ", remoteOffset = " + remoteOffset);
 
 		String filename = basePath + "/fooOutputStream" + length;
-		CrailFile file = fs.create(filename,CrailNodeType.DATAFILE,  CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT).get().asFile();
+		CrailFile file = fs.create(filename,CrailNodeType.DATAFILE,  CrailStorageClass.DEFAULT, CrailLocationClass.DEFAULT, true).get().asFile();
 		CrailOutputStream outputStream = file.getDirectOutputStream(0);
 		CrailInputStream inputStream = file.getDirectInputStream(0);
 

--- a/hdfs/src/main/java/org/apache/crail/hdfs/CrailHDFS.java
+++ b/hdfs/src/main/java/org/apache/crail/hdfs/CrailHDFS.java
@@ -96,7 +96,7 @@ public class CrailHDFS extends AbstractFileSystem {
 	public FSDataOutputStream createInternal(Path path, EnumSet<CreateFlag> flag, FsPermission absolutePermission, int bufferSize, short replication, long blockSize, Progressable progress, ChecksumOpt checksumOpt, boolean createParent) throws AccessControlException, FileAlreadyExistsException, FileNotFoundException, ParentNotDirectoryException, UnsupportedFileSystemException, UnresolvedLinkException, IOException {
 		CrailFile fileInfo = null;
 		try {
-			fileInfo = dfs.create(path.toUri().getRawPath(), CrailNodeType.DATAFILE, CrailStorageClass.PARENT, CrailLocationClass.PARENT).get().asFile();
+			fileInfo = dfs.create(path.toUri().getRawPath(), CrailNodeType.DATAFILE, CrailStorageClass.PARENT, CrailLocationClass.PARENT, true).get().asFile();
 		} catch(Exception e){
 			if (e.getMessage().contains(RpcErrors.messages[RpcErrors.ERR_PARENT_MISSING])){
 				fileInfo = null;
@@ -109,7 +109,7 @@ public class CrailHDFS extends AbstractFileSystem {
 			Path parent = path.getParent();
 			this.mkdir(parent, FsPermission.getDirDefault(), true);
 			try {
-				fileInfo = dfs.create(path.toUri().getRawPath(), CrailNodeType.DATAFILE, CrailStorageClass.PARENT, CrailLocationClass.PARENT).get().asFile();
+				fileInfo = dfs.create(path.toUri().getRawPath(), CrailNodeType.DATAFILE, CrailStorageClass.PARENT, CrailLocationClass.PARENT, true).get().asFile();
 			} catch(Exception e){
 				throw new IOException(e);
 			}
@@ -137,7 +137,7 @@ public class CrailHDFS extends AbstractFileSystem {
 	@Override
 	public void mkdir(Path path, FsPermission permission, boolean createParent) throws AccessControlException, FileAlreadyExistsException, FileNotFoundException, UnresolvedLinkException, IOException {
 		try {
-			CrailDirectory file = dfs.create(path.toUri().getRawPath(), CrailNodeType.DIRECTORY, CrailStorageClass.PARENT, CrailLocationClass.DEFAULT).get().asDirectory();
+			CrailDirectory file = dfs.create(path.toUri().getRawPath(), CrailNodeType.DIRECTORY, CrailStorageClass.PARENT, CrailLocationClass.DEFAULT, true).get().asDirectory();
 			file.syncDir();
 		} catch(Exception e){
 			if (e.getMessage().contains(RpcErrors.messages[RpcErrors.ERR_PARENT_MISSING])){

--- a/hdfs/src/main/java/org/apache/crail/hdfs/CrailHadoopFileSystem.java
+++ b/hdfs/src/main/java/org/apache/crail/hdfs/CrailHadoopFileSystem.java
@@ -104,7 +104,7 @@ public class CrailHadoopFileSystem extends FileSystem {
 			long blockSize, Progressable progress) throws IOException {
 		CrailFile fileInfo = null;
 		try {
-			fileInfo = dfs.create(path.toUri().getRawPath(), CrailNodeType.DATAFILE, CrailStorageClass.PARENT, CrailLocationClass.PARENT).get().asFile();
+			fileInfo = dfs.create(path.toUri().getRawPath(), CrailNodeType.DATAFILE, CrailStorageClass.PARENT, CrailLocationClass.PARENT, true).get().asFile();
 		} catch (Exception e) {
 			if (e.getMessage().contains(RpcErrors.messages[RpcErrors.ERR_PARENT_MISSING])) {
 				fileInfo = null;
@@ -117,7 +117,7 @@ public class CrailHadoopFileSystem extends FileSystem {
 			Path parent = path.getParent();
 			this.mkdirs(parent, FsPermission.getDirDefault());
 			try {
-				fileInfo = dfs.create(path.toUri().getRawPath(), CrailNodeType.DATAFILE, CrailStorageClass.PARENT, CrailLocationClass.PARENT).get().asFile();
+				fileInfo = dfs.create(path.toUri().getRawPath(), CrailNodeType.DATAFILE, CrailStorageClass.PARENT, CrailLocationClass.PARENT, true).get().asFile();
 			} catch (Exception e) {
 				throw new IOException(e);
 			}
@@ -210,7 +210,7 @@ public class CrailHadoopFileSystem extends FileSystem {
 	@Override
 	public boolean mkdirs(Path path, FsPermission permission) throws IOException {
 		try {
-			CrailDirectory file = dfs.create(path.toUri().getRawPath(), CrailNodeType.DIRECTORY, CrailStorageClass.PARENT, CrailLocationClass.DEFAULT).get().asDirectory();
+			CrailDirectory file = dfs.create(path.toUri().getRawPath(), CrailNodeType.DIRECTORY, CrailStorageClass.PARENT, CrailLocationClass.DEFAULT, true).get().asDirectory();
 			file.syncDir();
 			return true;
 		} catch(Exception e){

--- a/namenode/src/main/java/org/apache/crail/namenode/AbstractNode.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/AbstractNode.java
@@ -51,8 +51,8 @@ public abstract class AbstractNode extends FileInfo implements Delayed {
 	//clear all the blocks (used by GC)
 	public abstract void freeBlocks(BlockStore blockStore) throws Exception;	
 	
-	public AbstractNode(long fd, int fileComponent, CrailNodeType type, int storageClass, int locationAffinity){
-		super(fd, type);
+	public AbstractNode(long fd, int fileComponent, CrailNodeType type, int storageClass, int locationAffinity, boolean enumerable){
+		super(fd, type, enumerable);
 		
 		this.fileComponent = fileComponent;
 		this.storageClass = storageClass;

--- a/namenode/src/main/java/org/apache/crail/namenode/DirectoryBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/DirectoryBlocks.java
@@ -29,12 +29,12 @@ import org.apache.crail.conf.CrailConstants;
 import org.apache.crail.metadata.BlockInfo;
 
 public class DirectoryBlocks extends AbstractNode {
-	private AtomicLong dirOffsetCounter;
+	protected AtomicLong dirOffsetCounter;
 	protected ConcurrentHashMap<Integer, AbstractNode> children;	
 	private ConcurrentHashMap<Integer, NameNodeBlockInfo> blocks;
 	
-	DirectoryBlocks(long fd, int fileComponent, CrailNodeType type, int storageClass, int locationClass) {
-		super(fd, fileComponent, type, storageClass, locationClass);
+	DirectoryBlocks(long fd, int fileComponent, CrailNodeType type, int storageClass, int locationClass, boolean enumerable) {
+		super(fd, fileComponent, type, storageClass, locationClass, enumerable);
 		this.children = new ConcurrentHashMap<Integer, AbstractNode>();
 		this.dirOffsetCounter = new AtomicLong(0);
 		this.blocks = new ConcurrentHashMap<Integer, NameNodeBlockInfo>();
@@ -45,7 +45,9 @@ public class DirectoryBlocks extends AbstractNode {
 		if (old != null){
 			throw new Exception("File exists");
 		}
-		child.setDirOffset(dirOffsetCounter.getAndAdd(CrailConstants.DIRECTORY_RECORD));
+		if (child.isEnumerable()) {
+			child.setDirOffset(dirOffsetCounter.getAndAdd(CrailConstants.DIRECTORY_RECORD));
+		}
 		return old;
 	}	
 	

--- a/namenode/src/main/java/org/apache/crail/namenode/FileBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/FileBlocks.java
@@ -34,8 +34,8 @@ public class FileBlocks extends AbstractNode {
 	private final Lock readLock;
 	private final Lock writeLock;
 	
-	public FileBlocks(long fd, int fileComponent, CrailNodeType type, int storageClass, int locationClass) {
-		super(fd, fileComponent, type, storageClass, locationClass);
+	public FileBlocks(long fd, int fileComponent, CrailNodeType type, int storageClass, int locationClass, boolean enumerable) {
+		super(fd, fileComponent, type, storageClass, locationClass, enumerable);
 		this.blocks = new ArrayList<NameNodeBlockInfo>(CrailConstants.NAMENODE_FILEBLOCKS);
 		this.lock = new ReentrantReadWriteLock();
 		this.readLock = lock.readLock();

--- a/namenode/src/main/java/org/apache/crail/namenode/FileStore.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/FileStore.java
@@ -33,20 +33,20 @@ public class FileStore {
 	
 	public FileStore(Sequencer sequencer) throws IOException { 
 		this.sequencer = sequencer;
-		this.root = createNode(new FileName("/").getFileComponent(), CrailNodeType.DIRECTORY, CrailConstants.STORAGE_ROOTCLASS, 0);
+		this.root = createNode(new FileName("/").getFileComponent(), CrailNodeType.DIRECTORY, CrailConstants.STORAGE_ROOTCLASS, 0, false);
 	}
 	
-	public AbstractNode createNode(int fileComponent, CrailNodeType type, int storageClass, int locationClass) throws IOException {
+	public AbstractNode createNode(int fileComponent, CrailNodeType type, int storageClass, int locationClass, boolean enumerable) throws IOException {
 		if (type == CrailNodeType.DIRECTORY){
-			return new DirectoryBlocks(sequencer.getNextId(), fileComponent, type, storageClass, locationClass);
+			return new DirectoryBlocks(sequencer.getNextId(), fileComponent, type, storageClass, locationClass, enumerable);
 		} else if (type == CrailNodeType.MULTIFILE){
-			return new MultiFileBlocks(sequencer.getNextId(), fileComponent, type, storageClass, locationClass);
+			return new MultiFileBlocks(sequencer.getNextId(), fileComponent, type, storageClass, locationClass, enumerable);
 		} else if (type == CrailNodeType.TABLE){
-			return new TableBlocks(sequencer.getNextId(), fileComponent, type, storageClass, locationClass);
+			return new TableBlocks(sequencer.getNextId(), fileComponent, type, storageClass, locationClass, enumerable);
 		} else if (type == CrailNodeType.KEYVALUE){
-			return new KeyValueBlocks(sequencer.getNextId(), fileComponent, type, storageClass, locationClass);
+			return new KeyValueBlocks(sequencer.getNextId(), fileComponent, type, storageClass, locationClass, enumerable);
 		} else if (type == CrailNodeType.DATAFILE){
-			return new FileBlocks(sequencer.getNextId(), fileComponent, type, storageClass, locationClass);
+			return new FileBlocks(sequencer.getNextId(), fileComponent, type, storageClass, locationClass, enumerable);
 		} else {
 			throw new IOException("File type unkown: " + type);
 		}

--- a/namenode/src/main/java/org/apache/crail/namenode/KeyValueBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/KeyValueBlocks.java
@@ -23,8 +23,8 @@ import org.apache.crail.CrailNodeType;
 
 public class KeyValueBlocks extends FileBlocks {
 	public KeyValueBlocks(long fd, int fileComponent, CrailNodeType type,
-			int storageClass, int locationClass) {
-		super(fd, fileComponent, type, storageClass, locationClass);
+			int storageClass, int locationClass, boolean enumerable) {
+		super(fd, fileComponent, type, storageClass, locationClass, enumerable);
 	}
 
 }

--- a/namenode/src/main/java/org/apache/crail/namenode/MultiFileBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/MultiFileBlocks.java
@@ -24,8 +24,8 @@ import org.apache.crail.CrailNodeType;
 public class MultiFileBlocks extends DirectoryBlocks {
 
 	MultiFileBlocks(long fd, int fileComponent, CrailNodeType type,
-			int storageClass, int locationClass) {
-		super(fd, fileComponent, type, storageClass, locationClass);
+			int storageClass, int locationClass, boolean enumerable) {
+		super(fd, fileComponent, type, storageClass, locationClass, enumerable);
 	}
 
 }

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -90,6 +90,7 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		boolean writeable = type.isDirectory() ? false : true; 
 		int storageClass = request.getStorageClass();
 		int locationClass = request.getLocationClass();
+		boolean enumerable = request.isEnumerable();
 		
 		//check params
 		if (type.isContainer() && locationClass > 0){
@@ -115,7 +116,7 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 			locationClass = parentInfo.getLocationClass();
 		}
 		
-		AbstractNode fileInfo = fileTree.createNode(fileHash.getFileComponent(), type, storageClass, locationClass);
+		AbstractNode fileInfo = fileTree.createNode(fileHash.getFileComponent(), type, storageClass, locationClass, enumerable);
 		try {
 			AbstractNode oldNode = parentInfo.putChild(fileInfo);
 			if (oldNode != null && oldNode.getFd() != fileInfo.getFd()){

--- a/namenode/src/main/java/org/apache/crail/namenode/TableBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/TableBlocks.java
@@ -20,12 +20,13 @@
 package org.apache.crail.namenode;
 
 import org.apache.crail.CrailNodeType;
+import org.apache.crail.conf.CrailConstants;
 
 public class TableBlocks extends DirectoryBlocks {
 
 	TableBlocks(long fd, int fileComponent, CrailNodeType type,
-			int storageClass, int locationClass) {
-		super(fd, fileComponent, type, storageClass, locationClass);
+			int storageClass, int locationClass, boolean enumerable) {
+		super(fd, fileComponent, type, storageClass, locationClass, enumerable);
 	}
 
 	@Override
@@ -34,6 +35,10 @@ public class TableBlocks extends DirectoryBlocks {
 			throw new Exception("Attempt to create key/value pair in container other than a table");
 		}
 		
-		return children.put(child.getComponent(), child);
+		AbstractNode oldNode = children.put(child.getComponent(), child);
+		if (child.isEnumerable()) {
+			child.setDirOffset(dirOffsetCounter.getAndAdd(CrailConstants.DIRECTORY_RECORD));
+		}		
+		return oldNode;
 	}
 }

--- a/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeConnection.java
+++ b/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeConnection.java
@@ -60,12 +60,12 @@ public class DaRPCNameNodeConnection implements RpcConnection {
 	}	
 	
 	@Override
-	public RpcFuture<RpcCreateFile> createFile(FileName filename, CrailNodeType type, int storageClass, int locationClass) throws IOException {
+	public RpcFuture<RpcCreateFile> createFile(FileName filename, CrailNodeType type, int storageClass, int locationClass, boolean enumerable) throws IOException {
 		if (CrailConstants.DEBUG){
 			LOG.debug("RPC: createFile, fileType " + type + ", storageClass " + storageClass + ", locationClass " + locationClass);
 		}
 		
-		RpcRequestMessage.CreateFileReq createFileReq = new RpcRequestMessage.CreateFileReq(filename, type, storageClass, locationClass);
+		RpcRequestMessage.CreateFileReq createFileReq = new RpcRequestMessage.CreateFileReq(filename, type, storageClass, locationClass, enumerable);
 		DaRPCNameNodeRequest request = new DaRPCNameNodeRequest(createFileReq);
 		request.setCommand(RpcProtocol.CMD_CREATE_FILE);
 		

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
@@ -56,9 +56,9 @@ public class TcpRpcConnection implements RpcConnection {
 	}
 
 	public RpcFuture<RpcCreateFile> createFile(FileName fileName,
-			CrailNodeType type, int storageAffinity, int locationAffinity)
+			CrailNodeType type, int storageAffinity, int locationAffinity, boolean enumerable)
 			throws IOException {
-		RpcRequestMessage.CreateFileReq req = new RpcRequestMessage.CreateFileReq(fileName, type, storageAffinity, locationAffinity);
+		RpcRequestMessage.CreateFileReq req = new RpcRequestMessage.CreateFileReq(fileName, type, storageAffinity, locationAffinity, enumerable);
 		RpcResponseMessage.CreateFileRes resp = new RpcResponseMessage.CreateFileRes();
 
 		TcpNameNodeRequest request = new TcpNameNodeRequest(req);


### PR DESCRIPTION
tables, key/value pairs, etc.) whether the node should be enumerable or
not. If a node is enumerable it will be included in an enumeration
operation of the parent node.

https://issues.apache.org/jira/browse/CRAIL-10