### PR TITLE
Fixes issue with local short circuit (memcpy) path in the RDMA storage

### DIFF
--- a/client/src/main/java/org/apache/crail/conf/CrailConstants.java
+++ b/client/src/main/java/org/apache/crail/conf/CrailConstants.java
@@ -28,7 +28,7 @@ public class CrailConstants {
 	private static final Logger LOG = CrailUtils.getLogger();
 	
 	public static final String VERSION_KEY = "crail.version";
-	public static int VERSION = 3003;
+	public static int VERSION = 3004;
 	
 	public static final String DIRECTORY_DEPTH_KEY = "crail.directorydepth";
 	public static int DIRECTORY_DEPTH = 16;

--- a/storage-rdma/src/main/java/org/apache/crail/storage/rdma/client/RdmaStorageLocalEndpoint.java
+++ b/storage-rdma/src/main/java/org/apache/crail/storage/rdma/client/RdmaStorageLocalEndpoint.java
@@ -61,11 +61,10 @@ public class RdmaStorageLocalEndpoint implements StorageEndpoint {
 		this.address = datanodeAddr;
 		this.bufferMap = new ConcurrentHashMap<Long, CrailBuffer>();
 		this.unsafe = getUnsafe();
-		long lba = 0;
 		for (File dataFile : dataDir.listFiles()) {
-			MappedByteBuffer mappedBuffer = mmap(dataFile);
-			bufferMap.put(lba, OffHeapBuffer.wrap(mappedBuffer));
-			lba += mappedBuffer.capacity();
+			long lba = Long.parseLong(dataFile.getName());
+			OffHeapBuffer offHeapBuffer = OffHeapBuffer.wrap(mmap(dataFile));
+			bufferMap.put(lba, offHeapBuffer);
 		}				
 	}
 
@@ -134,7 +133,7 @@ public class RdmaStorageLocalEndpoint implements StorageEndpoint {
 	}
 	
 	private static long getAlignedLba(long remoteLba){
-		return (remoteLba / RdmaConstants.STORAGE_RDMA_ALLOCATION_SIZE) * RdmaConstants.STORAGE_RDMA_ALLOCATION_SIZE;
+		return remoteLba / RdmaConstants.STORAGE_RDMA_ALLOCATION_SIZE;
 	}
 	
 	private static long getLbaOffset(long remoteLba){


### PR DESCRIPTION
tier
- mmaped buffers were previously indexed with wrong LBA in
  RdmaStorageLocalEndpoint

This fixes the CRAIL-3 JIRA ticket
https://issues.apache.org/jira/browse/CRAIL-3

Signed-off-by: Patrick Stuedi <pstuedi@apache.org>