### PR TITLE
BufferedOutputStream: align CoreStream position

### DIFF
--- a/client/src/main/java/org/apache/crail/CrailOutputStream.java
+++ b/client/src/main/java/org/apache/crail/CrailOutputStream.java
@@ -23,10 +23,10 @@ import java.io.IOException;
 import java.util.concurrent.Future;
 
 public interface CrailOutputStream {
-	public CrailNode getFile();
-	public Future<CrailResult> write(CrailBuffer dataBuf) throws Exception;
-	public Future<Void> sync() throws IOException;
-	public long position();
-	public long getWriteHint();
-	public void close() throws Exception;
+	CrailNode getFile();
+	Future<CrailResult> write(CrailBuffer dataBuf) throws Exception;
+	Future<Void> sync() throws IOException;
+	long position();
+	long getWriteHint();
+	void close() throws Exception;
 }


### PR DESCRIPTION
After reopening an BufferedOutputStream the underlying CoreStream
might be at an arbitrary position since the stream is purged on close.
To avoid unnecessary operations on the underlying stream,
e.g. because of slices crossing the block boundary we adjust
the length of the first slice to align the position to slice size
such that after the first write all following writes on the underlying
stream will be aligned to slice size again. This also helps to avoid
unaligned writes in block storage tiers.

https://issues.apache.org/jira/browse/CRAIL-17

Signed-off-by: Jonas Pfefferle <pepperjo@apache.org>