### PR TITLE
Include test-jars and dependencies in assembly

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -43,6 +43,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.crail</groupId>
+      <artifactId>crail-client</artifactId>
+      <version>1.0</version>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.crail</groupId>
       <artifactId>crail-namenode</artifactId>
       <version>1.0</version>
     </dependency>
@@ -60,6 +66,12 @@
       <groupId>org.apache.crail</groupId>
       <artifactId>crail-storage-nvmf</artifactId>
       <version>1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.crail</groupId>
+      <artifactId>crail-storage-nvmf</artifactId>
+      <version>1.0</version>
+      <type>test-jar</type>
     </dependency>
     <dependency>
       <groupId>org.apache.crail</groupId>
@@ -102,7 +114,7 @@
 
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <executions>       
+        <executions>
           <execution>
             <id>dist</id>
             <phase>package</phase>

--- a/assembly/src/main/assembly/assembly.xml
+++ b/assembly/src/main/assembly/assembly.xml
@@ -1,6 +1,6 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3" 
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd"> 
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
   <id>bin</id>
   <formats>
     <format>tar.gz</format>
@@ -36,6 +36,13 @@
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <unpack>false</unpack>
       <scope>runtime</scope>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+    <dependencySet>
+      <outputDirectory>jars</outputDirectory>
+      <useTransitiveDependencies>true</useTransitiveDependencies>
+      <unpack>false</unpack>
+      <scope>test</scope>
       <useProjectArtifact>false</useProjectArtifact>
     </dependencySet>
   </dependencySets>

--- a/bin/crail
+++ b/bin/crail
@@ -30,6 +30,7 @@ function print_usage(){
   echo "  fsck                 run a Crail file check command"
   echo "  fs                   run a Crail shell command"
   echo "  iobench              run a Crail benchmark/test"
+  echo "  test                 run a Crail unit test"
 }
 
 if [ $# = 0 ]; then
@@ -59,9 +60,11 @@ elif [ "$COMMAND" = "fs" ] ; then
 elif [ "$COMMAND" = "getconf" ] ; then
   CLASS=org.apache.crail.hdfs.GetConf
 elif [ "$COMMAND" = "iobench" ] ; then
-  CLASS=org.apache.crail.tools.CrailBenchmark  
+  CLASS=org.apache.crail.tools.CrailBenchmark
 elif [ "$COMMAND" = "hdfsbench" ] ; then
-  CLASS=org.apache.crail.hdfs.tools.HdfsIOBenchmark    
+  CLASS=org.apache.crail.hdfs.tools.HdfsIOBenchmark
+elif [ "$COMMAND" = "test" ] ; then
+  CLASS=org.junit.runner.JUnitCore
 fi
 
 export CLASSPATH="$bin"/../jars/*:"$bin"/../conf:.


### PR DESCRIPTION
Add test-jars and test dependencies to jars directory.
Add test option to bin/crail to allow run unit tests from
command line.

Signed-off-by: Jonas Pfefferle <pepperjo@apache.org>