### PR TITLE
NVMf: decrease keep alive interval

### DIFF
--- a/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageConstants.java
+++ b/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageConstants.java
@@ -56,7 +56,7 @@ public class NvmfStorageConstants {
 	public static int STAGING_CACHE_SIZE = 262144;
 
 	/* We use the default keep alive timer of 120s in jNVMf */
-	public static long KEEP_ALIVE_INTERVAL_MS = TimeUnit.MILLISECONDS.convert(110, TimeUnit.SECONDS);
+	public static long KEEP_ALIVE_INTERVAL_MS = TimeUnit.MILLISECONDS.convert(60, TimeUnit.SECONDS);
 
 	private static String fullKey(String key) {
 		return PREFIX + "." + key;


### PR DESCRIPTION
Set keep alive interval to lower value to not run into the
situation where we missed the keep alive deadline and the connection
is shutdown by the controller.

https://issues.apache.org/jira/browse/CRAIL-32

Signed-off-by: Jonas Pfefferle <pepperjo@apache.org>