### PR TITLE
copyright & disclaimer

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,0 +1,3 @@
+The Crail project code was originally created, designed, developed (under an
+IBM copyright dated 2015-2017) and donated by the IBM Corporation (http://www.ibm.com/)
+to the Apache Software Foundation (ASF).

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,0 +1,12 @@
+Apache Crail (incubating) is an effort undergoing incubation at The
+Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+
+Incubation is required of all newly accepted
+projects until a further review indicates that the
+infrastructure, communications, and decision making process have
+stabilized in a manner consistent with other successful ASF
+projects.
+
+While incubation status is not necessarily a reflection
+of the completeness or stability of the code, it does indicate
+that the project has yet to be fully endorsed by the ASF.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,7 +17,7 @@ limitations under the License.
 {% endcomment %}
 -->
 
-## [1.0](https://github.com/apache/incubator-crail/tree/v1.0) - 27.04.2018
+## [1.0](https://github.com/apache/incubator-crail/tree/v1.0) - 23.05.2018
 
 This is our first Apache incubator release. Below are new features and bug fixes since the import to Apache.
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,5 @@
 Apache Crail incubating
-Copyright (C) 2017-2018, The Apache Software Foundation.
+Copyright 2017-2018 The Apache Software Foundation
 
-Copyright (C) 2015-2018, IBM Corporation
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
This pull request moves the IBM copyright from the NOTICE file to the CREDITS file and adds the Apache incubator disclaimer.