### PR TITLE
Make default configuration easier to run

### DIFF
--- a/client/src/main/java/org/apache/crail/CrailStore.java
+++ b/client/src/main/java/org/apache/crail/CrailStore.java
@@ -69,7 +69,7 @@ public abstract class CrailStore {
 
 	public static CrailStore newInstance(CrailConfiguration conf) throws Exception {
 		synchronized(referenceCounter){
-			boolean isSingleton = conf.getBoolean(CrailConstants.SINGLETON_KEY, false);
+			boolean isSingleton = conf.getBoolean(CrailConstants.SINGLETON_KEY, CrailConstants.SINGLETON);
 			if (isSingleton) {
 				referenceCounter.incrementAndGet();
 				if (instance == null) {

--- a/client/src/main/java/org/apache/crail/conf/CrailConstants.java
+++ b/client/src/main/java/org/apache/crail/conf/CrailConstants.java
@@ -36,16 +36,16 @@ public class CrailConstants {
 	public static long TOKEN_EXPIRATION = 10;
 
 	public static final String BLOCK_SIZE_KEY = "crail.blocksize";
-	public static long BLOCK_SIZE = 67108864;
+	public static long BLOCK_SIZE = 1048576;
 
 	public static final String CACHE_LIMIT_KEY = "crail.cachelimit";
 	public static long CACHE_LIMIT = 1073741824;
 
 	public static final String CACHE_PATH_KEY = "crail.cachepath";
-	public static String CACHE_PATH = "/home/stu/craildata/cache";
+	public static String CACHE_PATH = "/dev/hugepages/cache";
 
 	public static final String USER_KEY = "crail.user";
-	public static String USER = "stu";
+	public static String USER = "crail";
 
 	public static final String SHADOW_REPLICATION_KEY = "crail.shadowreplication";
 	public static int SHADOW_REPLICATION = 1;
@@ -69,7 +69,7 @@ public class CrailConstants {
 	public static int SLICE_SIZE = 524288;
 
 	public static final String SINGLETON_KEY = "crail.singleton";
-	public static boolean SINGLETON = false;
+	public static boolean SINGLETON = true;
 
 	public static final String REGION_SIZE_KEY = "crail.regionsize";
 	public static long REGION_SIZE = 1073741824;
@@ -88,7 +88,7 @@ public class CrailConstants {
 
 	//namenode interface
 	public static final String NAMENODE_ADDRESS_KEY = "crail.namenode.address";
-	public static String NAMENODE_ADDRESS = "";
+	public static String NAMENODE_ADDRESS = "crail://localhost:9060";
 
 	public static final String NAMENODE_FILEBLOCKS_KEY = "crail.namenode.fileblocks";
 	public static int NAMENODE_FILEBLOCKS = 16;

--- a/client/src/main/java/org/apache/crail/memory/MappedBufferCache.java
+++ b/client/src/main/java/org/apache/crail/memory/MappedBufferCache.java
@@ -54,7 +54,9 @@ public class MappedBufferCache extends BufferCache {
 			directory = CrailUtils.getCacheDirectory(id);
 			dir = new File(directory);
 			if (!dir.exists()){
-				dir.mkdirs();
+				if (!dir.mkdirs()) {
+					throw new IOException("Cannot create cache directory [crail.cachepath] set to path " + directory + ", check if crail.cachepath exists and has write permissions");
+				}
 			}
 			for (File child : dir.listFiles()) {
 				child.delete();

--- a/client/src/main/java/org/apache/crail/memory/MappedBufferCache.java
+++ b/client/src/main/java/org/apache/crail/memory/MappedBufferCache.java
@@ -53,13 +53,17 @@ public class MappedBufferCache extends BufferCache {
 			id = "" + System.currentTimeMillis();
 			directory = CrailUtils.getCacheDirectory(id);
 			dir = new File(directory);
-			if (!dir.exists()){
-				if (!dir.mkdirs()) {
-					throw new IOException("Cannot create cache directory [crail.cachepath] set to path " + directory + ", check if crail.cachepath exists and has write permissions");
+			try {
+				if (!dir.exists()){
+					if (!dir.mkdirs()) {
+						throw new IOException("Cannot create cache directory [crail.cachepath] set to path " + directory + ", check if crail.cachepath exists and has write permissions");
+					}
 				}
-			}
-			for (File child : dir.listFiles()) {
-				child.delete();
+				for (File child : dir.listFiles()) {
+					child.delete();
+				}
+			} catch(SecurityException e) {
+				throw new IOException("Security exception when trying to access " + directory + ", please check the directory permissions", e);
 			}
 		}
 	}

--- a/client/src/main/java/org/apache/crail/memory/MappedBufferCache.java
+++ b/client/src/main/java/org/apache/crail/memory/MappedBufferCache.java
@@ -54,10 +54,11 @@ public class MappedBufferCache extends BufferCache {
 			directory = CrailUtils.getCacheDirectory(id);
 			dir = new File(directory);
 			try {
-				if (!dir.exists()){
-					if (!dir.mkdirs()) {
-						throw new IOException("Cannot create cache directory [crail.cachepath] set to path " + directory + ", check if crail.cachepath exists and has write permissions");
-					}
+				if (dir.exists()) {
+					throw new IOException("A cache directory with the same id " + id + " already exists!");
+				}
+				if (!dir.mkdirs()) {
+					throw new IOException("Cannot create cache directory [crail.cachepath] set to path " + directory + ", check if crail.cachepath exists and has write permissions");
 				}
 				for (File child : dir.listFiles()) {
 					child.delete();

--- a/client/src/main/java/org/apache/crail/storage/StorageClient.java
+++ b/client/src/main/java/org/apache/crail/storage/StorageClient.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 
 import org.apache.crail.CrailBufferCache;
 import org.apache.crail.CrailStatistics;
-import org.apache.crail.conf.Configurable;
 import org.apache.crail.conf.CrailConfiguration;
 import org.apache.crail.metadata.DataNodeInfo;
 import org.slf4j.Logger;

--- a/client/src/test/java/org/apache/crail/ClientTest.java
+++ b/client/src/test/java/org/apache/crail/ClientTest.java
@@ -26,10 +26,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.Assert;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class ClientTest {

--- a/conf/core-site.xml.template
+++ b/conf/core-site.xml.template
@@ -23,7 +23,7 @@
   </property>
   <property>
     <name>fs.defaultFS</name>
-    <value>crail://hostname:9060</value>
+    <value>crail://localhost:9060</value>
   </property>
   <property>
     <name>fs.AbstractFileSystem.crail.impl</name>

--- a/conf/crail-site.conf.template
+++ b/conf/crail-site.conf.template
@@ -1,14 +1,7 @@
-crail.blocksize				1048576
-crail.buffersize			1048576
-crail.slicesize				524288
-crail.regionsize			1073741824
-crail.cachelimit			1073741824
-crail.cachepath				/dev/hugepages/cache	
-crail.singleton				true
-crail.statistics 			true
-crail.namenode.address			crail://localhost:9060
-crail.namenode.blockselection		roundrobin
-crail.namenode.darpc.queuesize		64
-crail.namenode.darpc.polling		false
-crail.storage.types 			org.apache.crail.storage.tcp.TcpStorageTier
+crail.namenode.address            crail://localhost:9060
+crail.cachepath                   /dev/hugepages/cache
+crail.cachelimit                  1073741824
+crail.storage.tcp.interface       eth0
+crail.storage.tcp.datapath        /dev/hugepages/data
+crail.storage.tcp.storagelimit    1073741824
 

--- a/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageConstants.java
+++ b/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageConstants.java
@@ -47,7 +47,7 @@ public class TcpStorageConstants {
 	public static long STORAGE_TCP_ALLOCATION_SIZE = CrailConstants.REGION_SIZE;	
 	
 	public static final String STORAGE_TCP_DATA_PATH_KEY = "crail.storage.tcp.datapath";
-	public static String STORAGE_TCP_DATA_PATH = "/home/stu/craildata/data";
+	public static String STORAGE_TCP_DATA_PATH = "/dev/hugepages/data";
 	
 	public static final String STORAGE_TCP_QUEUE_DEPTH_KEY = "crail.storage.tcp.queuedepth";
 	public static int STORAGE_TCP_QUEUE_DEPTH = 16;	

--- a/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
+++ b/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
@@ -167,7 +167,7 @@ public class TcpStorageServer implements Runnable, StorageServer, NaRPCService<T
 		
 		NetworkInterface netif = NetworkInterface.getByName(ifname);
 		if (netif == null){
-			return null;
+			throw new IOException("Cannot find network interface with name " + TcpStorageConstants.STORAGE_TCP_INTERFACE);
 		}
 		List<InterfaceAddress> addresses = netif.getInterfaceAddresses();
 		InetAddress addr = null;
@@ -176,13 +176,19 @@ public class TcpStorageServer implements Runnable, StorageServer, NaRPCService<T
 				InetAddress _addr = address.getAddress();
 				addr = _addr;
 			}
-		}		
+		}
+
+		if (addr == null){
+			throw new IOException("Cannot find valid network interface with name " + TcpStorageConstants.STORAGE_TCP_INTERFACE);
+		}
 		InetSocketAddress inetAddr = new InetSocketAddress(addr, port);
 		return inetAddr;
 	}	
 	
-	public static String getDatanodeDirectory(InetSocketAddress inetAddress){
-		String address = inetAddress.getAddress().toString();
-		return TcpStorageConstants.STORAGE_TCP_DATA_PATH + address + "-"  + inetAddress.getPort();
+	public static String getDatanodeDirectory(InetSocketAddress address) throws IllegalArgumentException {
+		if (address == null) {
+			throw new IllegalArgumentException("Address paramater cannot be null!");
+		}
+		return TcpStorageConstants.STORAGE_TCP_DATA_PATH + address.getAddress() + "-"  + address.getPort();
 	}	
 }

--- a/storage-nvmf/src/test/java/org/apache/crail/storage/nvmf/client/NvmfStagingBufferCacheTest.java
+++ b/storage-nvmf/src/test/java/org/apache/crail/storage/nvmf/client/NvmfStagingBufferCacheTest.java
@@ -23,8 +23,6 @@ import org.apache.crail.CrailBufferCache;
 import org.apache.crail.conf.CrailConfiguration;
 import org.apache.crail.conf.CrailConstants;
 import org.apache.crail.memory.MappedBufferCache;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 

--- a/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaConstants.java
+++ b/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaConstants.java
@@ -49,7 +49,7 @@ public class RdmaConstants {
 	public static long STORAGE_RDMA_ALLOCATION_SIZE = CrailConstants.REGION_SIZE;
 
 	public static final String STORAGE_RDMA_DATA_PATH_KEY = "crail.storage.rdma.datapath";
-	public static String STORAGE_RDMA_DATA_PATH = "/home/stu/craildata/data";
+	public static String STORAGE_RDMA_DATA_PATH = "/dev/hugepages/data";
 
 	public static final String STORAGE_RDMA_LOCAL_MAP_KEY = "crail.storage.rdma.localmap";
 	public static boolean STORAGE_RDMA_LOCAL_MAP = true;

--- a/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageServer.java
+++ b/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageServer.java
@@ -19,22 +19,18 @@
 package org.apache.crail.storage.rdma;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.InterfaceAddress;
-import java.net.NetworkInterface;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileChannel.MapMode;
-import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.crail.conf.CrailConfiguration;
 import org.apache.crail.storage.StorageResource;
 import org.apache.crail.storage.StorageServer;
+import org.apache.crail.storage.StorageUtils;
 import org.apache.crail.utils.CrailUtils;
 import org.slf4j.Logger;
 
@@ -65,7 +61,7 @@ public class RdmaStorageServer implements Runnable, StorageServer {
 	public void init(CrailConfiguration conf, String[] args) throws Exception {
 		RdmaConstants.init(conf, args);
 
-		this.serverAddr = getDataNodeAddress();
+		this.serverAddr = StorageUtils.getDataNodeAddress(RdmaConstants.STORAGE_RDMA_INTERFACE, RdmaConstants.STORAGE_RDMA_PORT);
 		if (serverAddr == null){
 			LOG.info("Configured network interface " + RdmaConstants.STORAGE_RDMA_INTERFACE + " cannot be found..exiting!!!");
 			return;
@@ -156,27 +152,6 @@ public class RdmaStorageServer implements Runnable, StorageServer {
 		} else {
 			return RdmaConstants.STORAGE_RDMA_DATA_PATH + address + "-"  + inetAddress.getPort();
 		}
-	}
-	
-	public static InetSocketAddress getDataNodeAddress() throws IOException {
-		String ifname = RdmaConstants.STORAGE_RDMA_INTERFACE;
-		int port = RdmaConstants.STORAGE_RDMA_PORT;
-		
-		NetworkInterface netif = NetworkInterface.getByName(ifname);
-		if (netif == null){
-			return null;
-		}
-		List<InterfaceAddress> addresses = netif.getInterfaceAddresses();
-		InetAddress addr = null;
-		for (InterfaceAddress address: addresses){
-//			LOG.info("address* " + address.toString() + ", _addr " + _addr.toString() + ", isSiteLocal " + _addr.isSiteLocalAddress() + ", tmp " + tmp + ", size " + tmp.length + ", broadcast " + address.getBroadcast());
-			if (address.getBroadcast() != null){
-				InetAddress _addr = address.getAddress();
-				addr = _addr;
-			}
-		}		
-		InetSocketAddress inetAddr = new InetSocketAddress(addr, port);
-		return inetAddr;
 	}
 	
 	@Override

--- a/storage/src/main/java/org/apache/crail/storage/StorageUtils.java
+++ b/storage/src/main/java/org/apache/crail/storage/StorageUtils.java
@@ -1,0 +1,49 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.crail.storage;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.util.List;
+
+public class StorageUtils {
+	public static InetSocketAddress getDataNodeAddress(String ifname, int port) throws IOException {
+		NetworkInterface netif = NetworkInterface.getByName(ifname);
+		if (netif == null){
+			throw new IOException("Cannot find network interface with name " + ifname);
+		}
+		List<InterfaceAddress> addresses = netif.getInterfaceAddresses();
+		InetAddress addr = null;
+		for (InterfaceAddress address: addresses){
+			if (address.getBroadcast() != null){
+				InetAddress _addr = address.getAddress();
+				addr = _addr;
+			}
+		}
+
+		if (addr == null){
+			throw new IOException("Network interface with name " + ifname + " has no valid IP address");
+		}
+		InetSocketAddress inetAddr = new InetSocketAddress(addr, port);
+		return inetAddr;
+	}	
+}


### PR DESCRIPTION
Better default values for cachepath and tcp storage path. Throw an
exception if paths are invalid. Throw an exception if interface is
invalid. Trim down crail-site.conf.template to only include the
necessary parameters.

https://issues.apache.org/jira/browse/CRAIL-15

Signed-off-by: Patrick Stuedi <pstuedi@apache.org>