### PR TITLE
Start script: remove heap size argument

### DIFF
--- a/bin/crail
+++ b/bin/crail
@@ -67,7 +67,15 @@ elif [ "$COMMAND" = "test" ] ; then
   CLASS=org.junit.runner.JUnitCore
 fi
 
-export CLASSPATH="$bin"/../jars/*:"$bin"/../conf:.
+CONF_PATH="$bin"/../conf
+export CLASSPATH="$bin"/../jars/*:${CONF_PATH}:.
 export LD_LIBRARY_PATH="$bin/../lib:$LD_LIBRARY_PATH"
 
-exec "$JAVA" -Dproc_$COMMAND -Dsun.nio.PageAlignDirectMemory=true $CLASS "$@"
+if [ -f "${CONF_PATH}/crail-env.sh" ]; then
+  # Promote all variable declarations to environment (exported) variables
+  set -a
+  . "${CONF_PATH}/crail-env.sh"
+  set +a
+fi
+
+exec "$JAVA" -Dproc_$COMMAND -Dsun.nio.PageAlignDirectMemory=true $CRAIL_EXTRA_JAVA_OPTIONS $CLASS "$@"

--- a/bin/crail
+++ b/bin/crail
@@ -50,11 +50,11 @@ case $COMMAND in
 esac
 
 if [ "$COMMAND" = "namenode" ] ; then
-  CLASS='org.apache.crail.namenode.NameNode'
+  CLASS=org.apache.crail.namenode.NameNode
 elif [ "$COMMAND" = "datanode" ] ; then
-  CLASS='org.apache.crail.storage.StorageServer'
+  CLASS=org.apache.crail.storage.StorageServer
 elif [ "$COMMAND" = "fsck" ] ; then
-  CLASS='org.apache.crail.tools.CrailFsck'
+  CLASS=org.apache.crail.tools.CrailFsck
 elif [ "$COMMAND" = "fs" ] ; then
   CLASS=org.apache.hadoop.fs.FsShell
 elif [ "$COMMAND" = "getconf" ] ; then
@@ -70,4 +70,4 @@ fi
 export CLASSPATH="$bin"/../jars/*:"$bin"/../conf:.
 export LD_LIBRARY_PATH="$bin/../lib:$LD_LIBRARY_PATH"
 
-exec "$JAVA" -Dproc_$COMMAND -XX:MaxDirectMemorySize=64G -Dsun.nio.PageAlignDirectMemory=true -Xmn16G $CLASS "$@"
+exec "$JAVA" -Dproc_$COMMAND -Dsun.nio.PageAlignDirectMemory=true $CLASS "$@"

--- a/conf/crail-env.sh.template
+++ b/conf/crail-env.sh.template
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# This env varibale allows setting additional java parameter
+#CRAIL_EXTRA_JAVA_OPTIONS="-Xmx24G -Xmn16G"


### PR DESCRIPTION
Remove Xmx and MaxDirectMemorySize argument from start script
since it does not allow to run Crail on machines with less
than 64G.

https://issues.apache.org/jira/browse/CRAIL-40

Signed-off-by: Jonas Pfefferle <pepperjo@apache.org>