### PR TITLE
Delegate implementation of CrailHDFS to CrailHadoopFileSystem

### DIFF
--- a/hdfs/src/main/java/org/apache/crail/hdfs/CrailHDFSInputStream.java
+++ b/hdfs/src/main/java/org/apache/crail/hdfs/CrailHDFSInputStream.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.ByteBufferReadable;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
+import org.apache.hadoop.fs.FileSystem.Statistics;
 import org.slf4j.Logger;
 
 
@@ -36,8 +37,9 @@ public class CrailHDFSInputStream extends FSDataInputStream {
 	private static final Logger LOG = CrailUtils.getLogger();
 	
 	private CrailBufferedInputStream inputStream;
+	private Statistics stats;
 	
-	public CrailHDFSInputStream(CrailBufferedInputStream stream) {
+	public CrailHDFSInputStream(CrailBufferedInputStream stream, Statistics stats) {
 		super(new CrailSeekable(stream));
 		LOG.info("new HDFS stream");
 		this.inputStream = stream;
@@ -50,13 +52,17 @@ public class CrailHDFSInputStream extends FSDataInputStream {
 
 	@Override
 	public int read(ByteBuffer buf) throws IOException {
-		return inputStream.read(buf);
+		int res = inputStream.read(buf);
+		updateStats(res);
+		return res;
 	}
 
 	@Override
 	public int read(long position, byte[] buffer, int offset, int length)
 			throws IOException {
-		return inputStream.read(position, buffer, offset, length);
+		int res = inputStream.read(position, buffer, offset, length);
+		updateStats(res);
+		return res;
 	}
 	
 	@Override
@@ -84,12 +90,20 @@ public class CrailHDFSInputStream extends FSDataInputStream {
 
 	@Override
 	public int read() throws IOException {
-		return inputStream.read();
+		int res = inputStream.read();
+		updateStats(res);
+		return res;
 	}
 
 	@Override
 	public int available() throws IOException {
 		return inputStream.available();
+	}
+	
+	private void updateStats(long len) {
+		if (stats != null && len > 0) {
+			stats.incrementBytesRead(len);
+		}
 	}
 	
 	public static class CrailSeekable extends InputStream implements Seekable, PositionedReadable, ByteBufferReadable {


### PR DESCRIPTION
Implement AbstractFileSystem by delegating function calls to
CrailHadoopFileSystm. The same can be done also by using
DelegateToFileSystem from hadoop-common, but this results in additional
operations (e.g., exists(path) and checkPath(path)).

https://issues.apache.org/jira/projects/CRAIL/issues/CRAIL-27

Signed-off-by: Patrick Stuedi <pstuedi@apache.com>