### PR TITLE
Throw more meaningful exception if datapath is invalid or has no write

### DIFF
--- a/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
+++ b/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
@@ -18,7 +18,6 @@
 
 package org.apache.crail.storage.tcp;
 
-import java.io.File;
 import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -64,8 +63,8 @@ public class TcpStorageServer implements Runnable, StorageServer, NaRPCService<T
 		this.regions = TcpStorageConstants.STORAGE_TCP_STORAGE_LIMIT/TcpStorageConstants.STORAGE_TCP_ALLOCATION_SIZE;
 		this.keys = 0;
 		this.dataBuffers = new ConcurrentHashMap<Integer, ByteBuffer>();
-		this.dataDirPath = getDatanodeDirectory(address);
-		clean();
+		this.dataDirPath = StorageUtils.getDatanodeDirectory(TcpStorageConstants.STORAGE_TCP_DATA_PATH, address);
+		StorageUtils.clean(TcpStorageConstants.STORAGE_TCP_DATA_PATH, dataDirPath);
 	}
 
 	@Override
@@ -145,21 +144,4 @@ public class TcpStorageServer implements Runnable, StorageServer, NaRPCService<T
 			return new TcpStorageResponse(TcpStorageProtocol.RET_RPC_UNKNOWN);
 		}
 	}
-	
-	private void clean(){
-		File dataDir = new File(dataDirPath);
-		if (!dataDir.exists()){
-			dataDir.mkdirs();
-		}
-		for (File child : dataDir.listFiles()) {
-			child.delete();
-		}
-	}	
-	
-	public static String getDatanodeDirectory(InetSocketAddress address) throws IllegalArgumentException {
-		if (address == null) {
-			throw new IllegalArgumentException("Address paramater cannot be null!");
-		}
-		return TcpStorageConstants.STORAGE_TCP_DATA_PATH + address.getAddress() + "-"  + address.getPort();
-	}	
 }

--- a/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageServer.java
+++ b/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageServer.java
@@ -18,7 +18,6 @@
 
 package org.apache.crail.storage.rdma;
 
-import java.io.File;
 import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -70,12 +69,11 @@ public class RdmaStorageServer implements Runnable, StorageServer {
 		datanodeGroup.init(new RdmaStorageEndpointFactory(datanodeGroup, this));
 		datanodeServerEndpoint.bind(serverAddr, RdmaConstants.STORAGE_RDMA_BACKLOG);
 		
-		this.dataDirPath = getDatanodeDirectory(serverAddr);
-		LOG.info("dataPath " + dataDirPath);
 		this.allocatedSize = 0;
 		this.fileCount = 0;
+		this.dataDirPath = StorageUtils.getDatanodeDirectory(RdmaConstants.STORAGE_RDMA_DATA_PATH, serverAddr);
 		if (!RdmaConstants.STORAGE_RDMA_PERSISTENT){
-			clean();		
+			StorageUtils.clean(RdmaConstants.STORAGE_RDMA_DATA_PATH, dataDirPath);		
 		} 
 	}
 	
@@ -141,29 +139,8 @@ public class RdmaStorageServer implements Runnable, StorageServer {
 		return serverAddr;
 	}	
 	
-	//--------------------
-	
-	public static String getDatanodeDirectory(InetSocketAddress inetAddress){
-		String address = inetAddress.getAddress().toString();
-		if (address.startsWith("/")){
-			return RdmaConstants.STORAGE_RDMA_DATA_PATH + address + "-"  + inetAddress.getPort();
-		} else {
-			return RdmaConstants.STORAGE_RDMA_DATA_PATH + address + "-"  + inetAddress.getPort();
-		}
-	}
-	
 	@Override
 	public boolean isAlive() {
 		return isAlive;
-	}
-
-	private void clean(){
-		File dataDir = new File(dataDirPath);
-		if (!dataDir.exists()){
-			dataDir.mkdirs();
-		}
-		for (File child : dataDir.listFiles()) {
-			child.delete();
-		}
 	}
 }

--- a/storage-rdma/src/main/java/org/apache/crail/storage/rdma/client/RdmaStorageLocalEndpoint.java
+++ b/storage-rdma/src/main/java/org/apache/crail/storage/rdma/client/RdmaStorageLocalEndpoint.java
@@ -35,8 +35,8 @@ import org.apache.crail.memory.OffHeapBuffer;
 import org.apache.crail.metadata.BlockInfo;
 import org.apache.crail.storage.StorageEndpoint;
 import org.apache.crail.storage.StorageFuture;
+import org.apache.crail.storage.StorageUtils;
 import org.apache.crail.storage.rdma.RdmaConstants;
-import org.apache.crail.storage.rdma.RdmaStorageServer;
 import org.apache.crail.utils.CrailUtils;
 import org.slf4j.Logger;
 
@@ -52,7 +52,7 @@ public class RdmaStorageLocalEndpoint implements StorageEndpoint {
 	
 	public RdmaStorageLocalEndpoint(InetSocketAddress datanodeAddr) throws Exception {
 		LOG.info("new local endpoint for address " + datanodeAddr);
-		String dataPath = RdmaStorageServer.getDatanodeDirectory(datanodeAddr);
+		String dataPath = StorageUtils.getDatanodeDirectory(RdmaConstants.STORAGE_RDMA_DATA_PATH, datanodeAddr);
 		File dataDir = new File(dataPath);
 		if (!dataDir.exists()){
 			throw new Exception("Local RDMA data path missing");

--- a/storage/src/main/java/org/apache/crail/storage/StorageUtils.java
+++ b/storage/src/main/java/org/apache/crail/storage/StorageUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.crail.storage;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -45,5 +46,28 @@ public class StorageUtils {
 		}
 		InetSocketAddress inetAddr = new InetSocketAddress(addr, port);
 		return inetAddr;
+	}
+	
+	public static void clean(String base, String path) throws IOException {
+		try {
+			File dataDir = new File(path);
+			if (!dataDir.exists()){
+				if (!dataDir.mkdirs()) {
+					throw new IOException("crail.datapath " + base + " either does not exist or has no write permissions");
+				}
+			}
+			for (File child : dataDir.listFiles()) {
+				child.delete();
+			}
+		} catch(SecurityException e) {
+			throw new IOException("Error when trying to access " + base, e);
+		}
+	}
+	
+	public static String getDatanodeDirectory(String datapath, InetSocketAddress address) throws IllegalArgumentException {
+		if (address == null) {
+			throw new IllegalArgumentException("Address paramater cannot be null!");
+		}
+		return datapath + address.getAddress() + "-"  + address.getPort();
 	}	
 }


### PR DESCRIPTION
permissions.

Fixes the issue of invalid datapath or missing write permissions on the
datapath for both the RDMA and the TCP storage tier.

https://issues.apache.org/jira/browse/CRAIL-45

Signed-off-by: Patrick Stuedi <pstuedi@apache.org>