### PR TITLE
Docker: fix base image url/tag and DiSNI version

### DIFF
--- a/docker/RDMA/Dockerfile
+++ b/docker/RDMA/Dockerfile
@@ -13,11 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.)
 
-FROM crail:latest
+# TODO: automate update version
+FROM apache/incubator-crail:1.1
 MAINTAINER Apache Crail <dev@crail.apache.org>
 
 # TODO: automate update version
-ARG DISNI_COMMIT="v1.5"
+ARG DISNI_COMMIT="v1.7"
 
 RUN echo "Crail-$LOG_COMMIT install rdma libraries and autotools" && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Fix base image url/tag and update DiSNI version to match version
in pom file.

https://jira.apache.org/jira/projects/CRAIL/issues/CRAIL-58

Signed-off-by: Jonas Pfefferle <pepperjo@apache.org>