### PR TITLE
[Documentation] fix path to crail script

### DIFF
--- a/doc/source/iobench.rst
+++ b/doc/source/iobench.rst
@@ -10,14 +10,14 @@ Synchronously write 1MB 1024 times to get a 1GB file:
 
 .. code-block:: bash
 
-   $CRAIL_HOME/crail iobench -t write -f /filename -s $((1024*1024)) -k 1024
+   $CRAIL_HOME/bin/crail iobench -t write -f /filename -s $((1024*1024)) -k 1024
 
 Read 1024 1MB buffers asynchronously with a batch size of 4:
 
 
 .. code-block:: bash
 
-   $CRAIL_HOME/crail iobench -t readSequentialAsync -f /filename -s $((1024*1024)) -k 1024 -b 4
+   $CRAIL_HOME/bin/crail iobench -t readSequentialAsync -f /filename -s $((1024*1024)) -k 1024 -b 4
 
 Command Reference
 -----------------

--- a/doc/source/run.rst
+++ b/doc/source/run.rst
@@ -12,14 +12,14 @@ To start the namenode execute the following command on the host that is configur
 
 .. code-block:: bash
 
-   $CRAIL_HOME/crail namenode
+   $CRAIL_HOME/bin/crail namenode
 
 To start a datanode run the following command on a host in the cluster
 (ideally this is a different physical machine than the one running the namenode):
 
 .. code-block:: bash
 
-   $CRAIL_HOME/crail datanode
+   $CRAIL_HOME/bin/crail datanode
 
 Now you should have a small deployment up with just one datanode.
 In this case the datanode is of type TCP/DRAM, which is the default datnode.
@@ -29,7 +29,7 @@ You can find a list of supported storage tiers :ref:`here <Storage Tiers>`. For 
 
 .. code-block:: bash
 
-   $CRAIL_HOME/crail datanode -t org.apache.crail.storage.nvmf.NvmfStorageTier
+   $CRAIL_HOME/bin/crail datanode -t org.apache.crail.storage.nvmf.NvmfStorageTier
 
 starts the NVMf datanode. Note that configuration in :ref:`crail-site.conf` needs
 to have the specific properties set of this type of datanode, in order for this to work.
@@ -38,7 +38,7 @@ properties on the command line which can be appended after :code:`--` to the com
 
 .. code-block:: bash
 
-   $CRAIL_HOME/crail datanode -t org.apache.crail.storage.nvmf.NvmfStorageTier -- -a 192.168.0.2
+   $CRAIL_HOME/bin/crail datanode -t org.apache.crail.storage.nvmf.NvmfStorageTier -- -a 192.168.0.2
 
 Each storage tier instance can only belong to one storage class however the same
 storage tier type can belong to multiple storage classes. Refer to :ref:`Storage Tiers`
@@ -50,7 +50,7 @@ in a specific storage class, e.g.:
 
 .. code-block:: bash
 
-   $CRAIL_HOME/crail datanode -t org.apache.crail.storage.nvmf.NvmfStorageTier -c 1
+   $CRAIL_HOME/bin/crail datanode -t org.apache.crail.storage.nvmf.NvmfStorageTier -c 1
 
 starts a NVMf storage tier in storage class 1 (storage classes start from 0).
 

--- a/doc/source/shell.rst
+++ b/doc/source/shell.rst
@@ -7,15 +7,15 @@ properly.
 
 .. code-block:: bash
 
-   $CRAIL_HOME/crail fs
+   $CRAIL_HOME/bin/crail fs
 
 Not all shell commands are support but the following operations have been tested to work:
 
 .. code-block:: bash
 
-   $CRAIL_HOME/crail fs -ls <crail_path>
-   $CRAIL_HOME/crail fs -mkdir <crail_path>
-   $CRAIL_HOME/crail fs -copyFromLocal <local_path> <crail_path>
-   $CRAIL_HOME/crail fs -copyToLocal <crail_path> <local_path>
-   $CRAIL_HOME/crail fs -cat <crail_path>
+   $CRAIL_HOME/bin/crail fs -ls <crail_path>
+   $CRAIL_HOME/bin/crail fs -mkdir <crail_path>
+   $CRAIL_HOME/bin/crail fs -copyFromLocal <local_path> <crail_path>
+   $CRAIL_HOME/bin/crail fs -copyToLocal <crail_path> <local_path>
+   $CRAIL_HOME/bin/crail fs -cat <crail_path>
 


### PR DESCRIPTION
Fix path to crail script. The correct path is $CRAIL_HOME/bin/crail

https://jira.apache.org/jira/browse/CRAIL-66

Signed-off-by: Jonas Pfefferle <pepperjo@apache.org>