### PR TITLE
[Build] fix source tarball name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>source-release-assembly</id>
+            <phase>package</phase>
+            <configuration combine.self="override">
+              <runOnlyAtExecutionRoot>true</runOnlyAtExecutionRoot>
+              <finalName>apache-crail-${project.version}</finalName>
+              <tarLongFileMode>posix</tarLongFileMode>
+              <descriptorRefs>
+                <descriptorRef>src</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Change name of source tarball to adhere to
apche-crail-X.Y-incubating-src

https://jira.apache.org/jira/projects/CRAIL/issues/CRAIL-56

Signed-off-by: Jonas Pfefferle <pepperjo@apache.org>