### PR TITLE
[Build] Append filename to checksum files

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -162,6 +162,7 @@
             <algorithm>SHA-512</algorithm>
           </algorithms>
           <failOnError>false</failOnError>
+          <appendFilename>true</appendFilename>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Append filename to checksum in checksum files. This allows to
check checksum with sha512sum -c <filename>

https://issues.apache.org/jira/projects/CRAIL/issues/CRAIL-73

Signed-off-by: Jonas Pfefferle <pepperjo@apache.org>