### PR TITLE
[Build] Fix source tarball not compiling

### DIFF
--- a/assembly/src/main/assembly/source-assembly.xml
+++ b/assembly/src/main/assembly/source-assembly.xml
@@ -80,8 +80,6 @@
 
         <exclude>**/*.swp</exclude>
         <exclude>doc/build/**</exclude>
-        <exclude>LICENSE-binary</exclude>
-        <exclude>licenses/**</exclude>
       </excludes>
     </fileSet>
     <!-- LICENSE, NOTICE, DEPENDENCIES -->


### PR DESCRIPTION
Add binary licenses to src tarball to allow to execute "mvn package"
which creates a binary tarball with said licenses.

Signed-off-by: Jonas Pfefferle <pepperjo@apache.org>