### PR TITLE
[NVMf] do not append port to subsystem NQN

### DIFF
--- a/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/client/NvmfStorageEndpoint.java
+++ b/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/client/NvmfStorageEndpoint.java
@@ -62,7 +62,7 @@ public class NvmfStorageEndpoint implements StorageEndpoint {
 				InetAddress.getByAddress(info.getIpAddress()), info.getPort());
 		// XXX FIXME: nsid from datanodeinfo
 		NvmfTransportId transportId = new NvmfTransportId(inetSocketAddress,
-				new NvmeQualifiedName(NvmfStorageConstants.NQN.toString() + info.getPort()));
+				new NvmeQualifiedName(NvmfStorageConstants.NQN.toString()));
 		LOG.info("Connecting to NVMf target at " + transportId.toString());
 		controller = nvme.connect(transportId);
 		controller.getControllerConfiguration().setEnable(true);


### PR DESCRIPTION
Appending the port to the subsystem NQN was introduced to allow
connecting to multiple targets on the same host. This problem occured
because we currently do not store subsystem NQN information at the
namenode, so there is only one global subsystem NQN in the configuration
file. For now we are removing this hack because it confuses users.