### PR TITLE
NVMf Host nqn configuration parameter

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -197,6 +197,7 @@ Property                                    Default Value               Descript
 :code:`crail.storage.nvmf.port`             50025                       Port of NVMf target
 :code:`crail.storage.nvmf.nqn`              nqn.2017-06.io.crail:cnode  NVMe qualified name of NVMf controller
 :code:`crail.storage.nvmf.namespace`        1                           Namespace of NVMe device
+:code:`crail.storage.nvmf.hostnqn`          <random 128bit UUID>        NVMe qualified name of host
 ========================================    ==========================  ============================================================
 
 Advanced properties:

--- a/doc/source/run.rst
+++ b/doc/source/run.rst
@@ -104,6 +104,7 @@ Argument                   crail-site.conf/Description
 :code:`-p <port>`          :code:`crail.storage.nvmf.port`
 :code:`-nqn <nqn>`         :code:`crail.storage.nvmf.nqn`
 :code:`-n <namespace_id>`  Namespace id to use (default 1)
+:code:`-hostnqn <nqn>`     :code:`crail.storage.nvmf.hostnqn`
 =========================  =====================================
 
 Larger deployments

--- a/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageClient.java
+++ b/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageClient.java
@@ -88,9 +88,13 @@ public class NvmfStorageClient implements StorageClient {
 		NvmfStorageConstants.printConf(logger);
 	}
 
-	private static Nvme getEndpointGroup() throws UnknownHostException {
+	private static Nvme getEndpointGroup() {
 		if (nvme == null) {
-			nvme = new Nvme();
+			if (NvmfStorageConstants.HOST_NQN == null) {
+				nvme = new Nvme();
+			} else {
+				nvme = new Nvme(NvmfStorageConstants.HOST_NQN);
+			}
 		}
 		return nvme;
 	}

--- a/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageConstants.java
+++ b/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageConstants.java
@@ -43,6 +43,9 @@ public class NvmfStorageConstants {
 	public static final String NQN_KEY = "nqn";
 	public static NvmeQualifiedName NQN = new NvmeQualifiedName("nqn.2017-06.io.crail:cnode");
 
+	public static final String HOST_NQN_KEY = "hostnqn";
+	public static NvmeQualifiedName HOST_NQN;
+
 	/* this is a server property, the client will get the nsid from the namenode */
 	public static NamespaceIdentifier NAMESPACE = new NamespaceIdentifier(1);
 
@@ -82,6 +85,11 @@ public class NvmfStorageConstants {
 			NQN = new NvmeQualifiedName(arg);
 		}
 
+		arg = get(conf, HOST_NQN_KEY);
+		if (arg != null) {
+			HOST_NQN = new NvmeQualifiedName(arg);
+		}
+
 		arg = get(conf, ALLOCATION_SIZE_KEY);
 		if (arg != null) {
 			ALLOCATION_SIZE = Integer.parseInt(arg);
@@ -114,6 +122,7 @@ public class NvmfStorageConstants {
 		}
 		logger.info(fullKey(PORT_KEY) + " " + PORT);
 		logger.info(fullKey(NQN_KEY) + " " + NQN);
+		logger.info(fullKey(HOST_NQN_KEY) + " " + HOST_NQN);
 		logger.info(fullKey(ALLOCATION_SIZE_KEY) + " " + ALLOCATION_SIZE);
 		logger.info(fullKey(QUEUE_SIZE_KEY) + " " + QUEUE_SIZE);
 	}
@@ -131,9 +140,11 @@ public class NvmfStorageConstants {
 			Option port = Option.builder("p").desc("target port").hasArg().type(Number.class).build();
 			Option namespace = Option.builder("n").desc("namespace id").hasArg().type(Number.class).build();
 			Option nqn = Option.builder("nqn").desc("target subsystem NQN").hasArg().build();
+			Option hostnqn = Option.builder("hostnqn").desc("host NQN").hasArg().build();
 			options.addOption(bindIp);
 			options.addOption(port);
 			options.addOption(nqn);
+			options.addOption(hostnqn);
 			options.addOption(namespace);
 			CommandLineParser parser = new DefaultParser();
 			HelpFormatter formatter = new HelpFormatter();
@@ -157,6 +168,9 @@ public class NvmfStorageConstants {
 			}
 			if (line.hasOption(nqn.getOpt())) {
 				NvmfStorageConstants.NQN = new NvmeQualifiedName(line.getOptionValue(nqn.getOpt()));
+			}
+			if (line.hasOption(hostnqn.getOpt())) {
+				NvmfStorageConstants.HOST_NQN = new NvmeQualifiedName(line.getOptionValue(hostnqn.getOpt()));
 			}
 		}
 

--- a/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageServer.java
+++ b/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageServer.java
@@ -47,7 +47,13 @@ public class NvmfStorageServer implements StorageServer {
 		initialized = true;
 		NvmfStorageConstants.parseCmdLine(crailConfiguration, args);
 
-		Nvme nvme = new Nvme();
+		Nvme nvme;
+		if (NvmfStorageConstants.HOST_NQN == null) {
+			nvme = new Nvme();
+		} else {
+			nvme = new Nvme(NvmfStorageConstants.HOST_NQN);
+		}
+
 		NvmfTransportId transportId = new NvmfTransportId(
 				new InetSocketAddress(NvmfStorageConstants.IP_ADDR, NvmfStorageConstants.PORT),
 				NvmfStorageConstants.NQN);


### PR DESCRIPTION
This adds a host NQN configuration parameter to allow setting the host NQN when connecting
to a NVMf target both from the client as from the datanode.