### PR TITLE
change the implement of $JAVA

### DIFF
--- a/bin/crail
+++ b/bin/crail
@@ -20,7 +20,6 @@ bin=`dirname ${bin}`
 bin=`cd "$bin"; pwd`
 
 LIBEXEC_DIR="$bin"/../libexec
-JAVA=$JAVA_HOME/bin/java
 
 function print_usage(){
   echo "Usage: crail COMMAND"
@@ -78,4 +77,4 @@ if [ -f "${CONF_PATH}/crail-env.sh" ]; then
   set +a
 fi
 
-exec "$JAVA" -Dproc_$COMMAND -Dsun.nio.PageAlignDirectMemory=true $CRAIL_EXTRA_JAVA_OPTIONS $CLASS "$@"
+exec "java" -Dproc_$COMMAND -Dsun.nio.PageAlignDirectMemory=true $CRAIL_EXTRA_JAVA_OPTIONS $CLASS "$@"

--- a/conf/crail-env.sh.template
+++ b/conf/crail-env.sh.template
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 # This env varibale allows setting additional java parameter
 #CRAIL_EXTRA_JAVA_OPTIONS="-Xmx24G -Xmn16G"
+
+bin=`dirname "${BASH_SOURCE-$0}"`
+bin=`cd "$bin"; pwd`
+export CRAIL_HOME="$bin"/..

--- a/libexec/crail-daemon.sh
+++ b/libexec/crail-daemon.sh
@@ -33,6 +33,14 @@ bin=`cd "$bin"; pwd`
 
 LIBEXEC_DIR="$bin"/../libexec
 
+CONF_PATH="$bin"/../conf
+if [ -f "${CONF_PATH}/crail-env.sh" ]; then
+  # Promote all variable declarations to environment (exported) variables
+  set -a
+  . "${CONF_PATH}/crail-env.sh"
+  set +a
+fi
+
 # get arguments
 
 #default value


### PR DESCRIPTION
we don't set $JAVA_HOME while installing JAVA, instead the var `java` is in execution path.
so we can use `java` directly.