### PR TITLE
can locationClass work properly？

### DIFF
--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -111,9 +111,6 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		if (storageClass < 0){
 			storageClass = parentInfo.getStorageClass();
 		}
-		if (locationClass < 0){
-			locationClass = parentInfo.getLocationClass();
-		}
 		
 		AbstractNode fileInfo = fileTree.createNode(fileHash.getFileComponent(), type, storageClass, locationClass, enumerable);
 		try {


### PR DESCRIPTION
in my view, the locationClass is initialized by this function:
```
public static CrailLocationClass getLocationClass() throws UnknownHostException{
	return CrailLocationClass.get(InetAddress.getLocalHost().getCanonicalHostName().hashCode());
}
```
The locationClass is a String's hashCode, so it can be a  negative number. However, in your code, the 
negative locationClass doesn't work at all.I think remove the judge of locationClass will be better.