### PR TITLE
DiSNI, DaRPC & jNVMf update

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -531,9 +531,9 @@ darpc-1.8.jar
 -------------
 Copyright (C) 2016-2018, IBM Corporation
 
-disni-2.0.jar
+disni-2.1.jar
 --------------
-Copyright (C) 2016-2018, IBM Corporation
+Copyright (C) 2016-2019, IBM Corporation
 
 gson-2.2.4.jar
 --------------

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -1001,9 +1001,9 @@ narpc-1.4.jar
 -------------
 Copyright (C) 2018, IBM Corporation
 
-jnvmf-1.5.jar
+jnvmf-1.6.jar
 -------------
-Copyright (C) 2018, IBM Corporation
+Copyright (C) 2018-2019, IBM Corporation
 
 jets3t-0.9.0.jar
 ----------------

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -527,9 +527,9 @@ From: 'The Netty Project' (http://netty.io/)
   - The Netty Project (http://netty.io/) io.netty:netty:bundle:3.7.0.Final
     License: Apache License, Version 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
-darpc-1.8.jar
+darpc-1.9.jar
 -------------
-Copyright (C) 2016-2018, IBM Corporation
+Copyright (C) 2016-2019, IBM Corporation
 
 disni-2.1.jar
 --------------

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
       <dependency>
         <groupId>com.ibm.disni</groupId>
         <artifactId>disni</artifactId>
-        <version>2.0</version>
+        <version>2.1</version>
       </dependency>
       <dependency>
         <groupId>com.ibm.darpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>com.ibm.jnvmf</groupId>
         <artifactId>jnvmf</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
       <dependency>
         <groupId>com.ibm.darpc</groupId>
         <artifactId>darpc</artifactId>
-        <version>1.8</version>
+        <version>1.9</version>
       </dependency>
       <dependency>
         <groupId>com.ibm.narpc</groupId>


### PR DESCRIPTION
New DiSNI version fixes hang issue with Spark: https://issues.apache.org/jira/browse/CRAIL-98
Please, pull and test. It might take a while until DiSNI, DaRPC and jNVMf are available in maven central.