### PR TITLE
Fix naming in Docker file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ RUN echo "Crail-$LOG_COMMIT clone & build Crail repo" && \
 RUN echo "Move crail to /crail" && \
     rm -rf /crail && \
     v=`xmllint --xpath "string(/*[local-name()='project']/*[local-name()='version'])" /incubator-crail/pom.xml` && \
-    mv /incubator-crail/assembly/target/crail-${v}-bin /crail
+    mv /incubator-crail/assembly/target/apache-crail-${v}-bin/apache-crail-${v} /crail
 
 ENV CRAIL_HOME /crail
 ENV PATH=${PATH}:${CRAIL_HOME}/bin


### PR DESCRIPTION
The wrong naming causes the docker build to fail. This commit
fixes the naming and resolves issue
https://issues.apache.org/jira/browse/CRAIL-99

Signed-off-by: Adrian Schuepbach <asq@apache.org>