### PR TITLE
Docker disni version

### DIFF
--- a/docker/RDMA/Dockerfile
+++ b/docker/RDMA/Dockerfile
@@ -17,13 +17,13 @@
 FROM apache/incubator-crail:1.1
 MAINTAINER Apache Crail <dev@crail.apache.org>
 
-# TODO: automate update version
-ARG DISNI_COMMIT="v1.7"
-
 RUN echo "Crail-$LOG_COMMIT install rdma libraries and autotools" && \
     apt-get install -y --no-install-recommends \
     autoconf autotools-dev automake libtool make g++ \
     librdmacm-dev libibverbs-dev ibverbs-providers
+
+RUN echo "Retrieve DiSNI jar version to match native library build" && \
+    DISNI_COMMIT=v$(ls $CRAIL_HOME/jars/disni* | grep -oP "\d+\.\d+(?=\.jar$)")
 
 RUN echo "Crail-$LOG_COMMIT clone and build disni native library" && \
     cd && git clone https://github.com/zrlio/disni.git && \

--- a/docker/RDMA/Dockerfile
+++ b/docker/RDMA/Dockerfile
@@ -18,7 +18,7 @@ FROM apache/incubator-crail:1.1
 MAINTAINER Apache Crail <dev@crail.apache.org>
 
 RUN echo "Crail-$LOG_COMMIT install rdma libraries and autotools" && \
-    apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends \
     autoconf autotools-dev automake libtool make g++ \
     librdmacm-dev libibverbs-dev ibverbs-providers
 


### PR DESCRIPTION
Automatically get libdisni version from DiSNI jar.
Before we had to manually update the DiSNI version
for building the native library on every release.