### PR TITLE
Make StoragerServer ep active to prevent orphaned CQ.

### DIFF
--- a/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageEndpointFactory.java
+++ b/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageEndpointFactory.java
@@ -25,9 +25,9 @@ import com.ibm.disni.verbs.*;
 
 public class RdmaStorageEndpointFactory implements RdmaEndpointFactory<RdmaStorageServerEndpoint> {
 	private RdmaStorageServer closer;
-	private RdmaPassiveEndpointGroup<RdmaStorageServerEndpoint> group;
+	private RdmaActiveEndpointGroup<RdmaStorageServerEndpoint> group;
 	
-	public RdmaStorageEndpointFactory(RdmaPassiveEndpointGroup<RdmaStorageServerEndpoint> group, RdmaStorageServer closer){
+	public RdmaStorageEndpointFactory(RdmaActiveEndpointGroup<RdmaStorageServerEndpoint> group, RdmaStorageServer closer){
 		this.group = group;
 		this.closer = closer;
 	}

--- a/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageServer.java
+++ b/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageServer.java
@@ -39,7 +39,7 @@ public class RdmaStorageServer implements Runnable, StorageServer {
 	private static final Logger LOG = CrailUtils.getLogger();
 	
 	private InetSocketAddress serverAddr;
-	private RdmaPassiveEndpointGroup<RdmaStorageServerEndpoint> datanodeGroup;
+	private RdmaActiveEndpointGroup<RdmaStorageServerEndpoint> datanodeGroup;
 	private RdmaServerEndpoint<RdmaStorageServerEndpoint> datanodeServerEndpoint;
 	private ConcurrentHashMap<Integer, RdmaEndpoint> allEndpoints; 
 	private boolean isAlive;
@@ -64,8 +64,8 @@ public class RdmaStorageServer implements Runnable, StorageServer {
 			LOG.info("Configured network interface " + RdmaConstants.STORAGE_RDMA_INTERFACE + " cannot be found..exiting!!!");
 			return;
 		}
-		this.datanodeGroup = new RdmaPassiveEndpointGroup<RdmaStorageServerEndpoint>(-1, RdmaConstants.STORAGE_RDMA_QUEUESIZE, 4, RdmaConstants.STORAGE_RDMA_QUEUESIZE*100);
-		this.datanodeServerEndpoint = datanodeGroup.createServerEndpoint();		
+		this.datanodeGroup = new RdmaActiveEndpointGroup<RdmaStorageServerEndpoint>(-1, false, 1, 1, 1);
+		this.datanodeServerEndpoint = datanodeGroup.createServerEndpoint();
 		datanodeGroup.init(new RdmaStorageEndpointFactory(datanodeGroup, this));
 		datanodeServerEndpoint.bind(serverAddr, RdmaConstants.STORAGE_RDMA_BACKLOG);
 		

--- a/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageServerEndpoint.java
+++ b/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageServerEndpoint.java
@@ -23,13 +23,17 @@ import java.io.IOException;
 import com.ibm.disni.verbs.*;
 import com.ibm.disni.*;
 
-public class RdmaStorageServerEndpoint extends RdmaEndpoint {
+public class RdmaStorageServerEndpoint extends RdmaActiveEndpoint {
 	private RdmaStorageServer closer;
 
-	public RdmaStorageServerEndpoint(RdmaPassiveEndpointGroup<RdmaStorageServerEndpoint> endpointGroup, RdmaCmId idPriv, RdmaStorageServer closer, boolean serverSide) throws IOException {	
+	public RdmaStorageServerEndpoint(RdmaActiveEndpointGroup<RdmaStorageServerEndpoint> endpointGroup, RdmaCmId idPriv, RdmaStorageServer closer, boolean serverSide) throws IOException {
 		super(endpointGroup, idPriv, serverSide);
 		this.closer = closer;
 	}	
+
+	public void dispatchCqEvent(IbvWC wc) throws IOException {
+
+	}
 	
 	public synchronized void dispatchCmEvent(RdmaCmEvent cmEvent)
 			throws IOException {


### PR DESCRIPTION
The passive endpoint model caused an orphaned CQ at DataNode
after each client disconnect. Each new client connection caused
creation of another CQ. Changing to an active endpoint model
frees the per client CQ after client disconnect. Since the CQ is
not actually used (the endpoint handles only RDMA Read and
Write from client side), the active endpoint gets created with
minimum resources (send/receive/completion queue size == 1),
and the CQ event dispatcher is a nop.

Signed-off-by: Bernard Metzler <bmt@zurich.ibm.com>