### PR TITLE
[NVMf] Make keepalive thread a daemon thread

### DIFF
--- a/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageClient.java
+++ b/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageClient.java
@@ -65,6 +65,7 @@ public class NvmfStorageClient implements StorageClient {
 				}
 			}
 		});
+		this.keepAliveThread.setDaemon(true);
 	}
 
 	boolean isAlive() {


### PR DESCRIPTION
Daemonize the keepalive thread to allow applications to
exit when the main method returns without closing the
storage client explicitly. For example, Spark has this
requirement.

https://issues.apache.org/jira/browse/CRAIL-98

Signed-off-by: Jonas Pfefferle <pepperjo@apache.org>