### PR TITLE
Resource Elasticity [1/3]

### DIFF
--- a/client/src/main/java/org/apache/crail/metadata/DataNodeStatistics.java
+++ b/client/src/main/java/org/apache/crail/metadata/DataNodeStatistics.java
@@ -22,29 +22,29 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 
 public class DataNodeStatistics {
-	public static final int CSIZE = 14;
-	
+	public static int CSIZE = DataNodeStatus.CSIZE + 12;
+
+	private DataNodeStatus status;
 	private long serviceId;
 	private int freeBlockCount;
-	private short status;
 	
 	public DataNodeStatistics(){
+		this.status = new DataNodeStatus();
 		this.serviceId = 0;
 		this.freeBlockCount = 0;
-		this.status = 0;
 	}
 	
 	public int write(ByteBuffer buffer){
+		this.status.write(buffer);
 		buffer.putLong(serviceId);
 		buffer.putInt(freeBlockCount);
-		buffer.putShort(status);
 		return CSIZE;
 	}
 	
 	public void update(ByteBuffer buffer) throws UnknownHostException {
+		this.status.update(buffer);
 		this.serviceId = buffer.getLong();
 		this.freeBlockCount = buffer.getInt();
-		this.status = buffer.getShort();
 	}
 
 	public int getFreeBlockCount() {
@@ -55,12 +55,12 @@ public class DataNodeStatistics {
 		this.freeBlockCount = blockCount;
 	}
 
-	public short getStatus() {
+	public DataNodeStatus getStatus() {
 		return this.status;
 	}
 
 	public void setStatus(short status) {
-		this.status = status;
+		this.status.setStatus(status);
 	}
 
 	public void setStatistics(DataNodeStatistics statistics) {

--- a/client/src/main/java/org/apache/crail/metadata/DataNodeStatistics.java
+++ b/client/src/main/java/org/apache/crail/metadata/DataNodeStatistics.java
@@ -22,25 +22,29 @@ import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 
 public class DataNodeStatistics {
-	public static final int CSIZE = 12;
+	public static final int CSIZE = 14;
 	
 	private long serviceId;
 	private int freeBlockCount;
+	private short status;
 	
 	public DataNodeStatistics(){
 		this.serviceId = 0;
 		this.freeBlockCount = 0;
+		this.status = 0;
 	}
 	
 	public int write(ByteBuffer buffer){
 		buffer.putLong(serviceId);
 		buffer.putInt(freeBlockCount);
+		buffer.putShort(status);
 		return CSIZE;
 	}
 	
 	public void update(ByteBuffer buffer) throws UnknownHostException {
 		this.serviceId = buffer.getLong();
 		this.freeBlockCount = buffer.getInt();
+		this.status = buffer.getShort();
 	}
 
 	public int getFreeBlockCount() {
@@ -49,6 +53,14 @@ public class DataNodeStatistics {
 
 	public void setFreeBlockCount(int blockCount) {
 		this.freeBlockCount = blockCount;
+	}
+
+	public short getStatus() {
+		return this.status;
+	}
+
+	public void setStatus(short status) {
+		this.status = status;
 	}
 
 	public void setStatistics(DataNodeStatistics statistics) {

--- a/client/src/main/java/org/apache/crail/metadata/DataNodeStatus.java
+++ b/client/src/main/java/org/apache/crail/metadata/DataNodeStatus.java
@@ -1,0 +1,32 @@
+package org.apache.crail.metadata;
+
+import java.nio.ByteBuffer;
+
+public class DataNodeStatus {
+    public static final int CSIZE = 2;
+
+    private short status;
+
+    public static final short STATUS_DATANODE_STOP = 1;
+
+    public DataNodeStatus() {
+        this.status = 0;
+    }
+
+    public int write(ByteBuffer buffer) {
+        buffer.putShort(status);
+        return CSIZE;
+    }
+
+    public void update(ByteBuffer buffer) {
+        this.status = buffer.getShort();
+    }
+
+    public short getStatus() {
+        return this.status;
+    }
+
+    public void setStatus(short status) {
+        this.status = status;
+    }
+}

--- a/client/src/main/java/org/apache/crail/rpc/RpcConnection.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcConnection.java
@@ -19,6 +19,7 @@
 package org.apache.crail.rpc;
 
 import java.io.IOException;
+import java.net.InetAddress;
 
 import org.apache.crail.CrailNodeType;
 import org.apache.crail.metadata.BlockInfo;
@@ -59,6 +60,9 @@ public interface RpcConnection {
 
 	public abstract RpcFuture<RpcPing> pingNameNode()
 			throws Exception;
+
+	public abstract RpcFuture<RpcRemoveDataNode> removeDataNode(
+			InetAddress ipaddr, int port) throws Exception;
 	
 	public abstract void close() throws Exception;
 	

--- a/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
@@ -19,6 +19,7 @@
 package org.apache.crail.rpc;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.crail.CrailNodeType;
@@ -132,6 +133,12 @@ public class RpcDispatcher implements RpcConnection {
 	@Override
 	public RpcFuture<RpcPing> pingNameNode() throws Exception {
 		return connections[0].pingNameNode();
+	}
+
+	@Override
+	public RpcFuture<RpcRemoveDataNode> removeDataNode(
+			InetAddress ipaddr, int port) throws Exception {
+		return connections[0].removeDataNode(ipaddr, port);
 	}
 
 	@Override

--- a/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcDispatcher.java
@@ -138,6 +138,9 @@ public class RpcDispatcher implements RpcConnection {
 	@Override
 	public RpcFuture<RpcRemoveDataNode> removeDataNode(
 			InetAddress ipaddr, int port) throws Exception {
+		if(connections.length > 1) {
+			throw new Exception("removeDataNode RPC currently not supported in multi-namenode environments");
+		}
 		return connections[0].removeDataNode(ipaddr, port);
 	}
 

--- a/client/src/main/java/org/apache/crail/rpc/RpcErrors.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcErrors.java
@@ -55,7 +55,8 @@ public class RpcErrors {
 	public static short ERR_DIR_LOCATION_AFFINITY_MISMATCH = 26;
 	public static short ERR_ADD_BLOCK_FAILED = 27;
 	public static short ERR_CREATE_FILE_BUG = 28;
-	
+	public static short ERR_DATANODE_STOP = 29;
+
 	static {
 		messages[ERR_OK] = "ERROR: No error, all fine";
 		messages[ERR_UNKNOWN] = "ERROR: Unknown error";

--- a/client/src/main/java/org/apache/crail/rpc/RpcErrors.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcErrors.java
@@ -55,7 +55,6 @@ public class RpcErrors {
 	public static short ERR_DIR_LOCATION_AFFINITY_MISMATCH = 26;
 	public static short ERR_ADD_BLOCK_FAILED = 27;
 	public static short ERR_CREATE_FILE_BUG = 28;
-	public static short ERR_DATANODE_STOP = 29;
 
 	static {
 		messages[ERR_OK] = "ERROR: No error, all fine";

--- a/client/src/main/java/org/apache/crail/rpc/RpcRemoveDataNode.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcRemoveDataNode.java
@@ -1,0 +1,5 @@
+package org.apache.crail.rpc;
+
+public interface RpcRemoveDataNode extends RpcResponse {
+    public short getData();
+}

--- a/client/src/main/java/org/apache/crail/rpc/RpcRemoveDataNode.java
+++ b/client/src/main/java/org/apache/crail/rpc/RpcRemoveDataNode.java
@@ -1,5 +1,5 @@
 package org.apache.crail.rpc;
 
 public interface RpcRemoveDataNode extends RpcResponse {
-    public short getData();
+    public short getRpcStatus();
 }

--- a/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeConnection.java
+++ b/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeConnection.java
@@ -19,6 +19,7 @@
 package org.apache.crail.namenode.rpc.darpc;
 
 import java.io.IOException;
+import java.net.InetAddress;
 
 import org.apache.crail.CrailNodeType;
 import org.apache.crail.conf.CrailConstants;
@@ -35,6 +36,7 @@ import org.apache.crail.rpc.RpcGetDataNode;
 import org.apache.crail.rpc.RpcGetFile;
 import org.apache.crail.rpc.RpcGetLocation;
 import org.apache.crail.rpc.RpcPing;
+import org.apache.crail.rpc.RpcRemoveDataNode;
 import org.apache.crail.rpc.RpcProtocol;
 import org.apache.crail.rpc.RpcRenameFile;
 import org.apache.crail.rpc.RpcRequestMessage;
@@ -267,6 +269,23 @@ public class DaRPCNameNodeConnection implements RpcConnection {
 		DaRPCNameNodeFuture<RpcPing> nameNodeFuture = new DaRPCNameNodeFuture<RpcPing>(future, pingRes);
 		
 		return nameNodeFuture;	
+	}
+
+	@Override
+	public RpcFuture<RpcRemoveDataNode> removeDataNode(InetAddress ipaddr, int port) throws Exception {
+
+		RpcRequestMessage.RemoveDataNodeReq removeDataNodeReq = new RpcRequestMessage.RemoveDataNodeReq(ipaddr, port);
+		DaRPCNameNodeRequest request = new DaRPCNameNodeRequest(removeDataNodeReq);
+		request.setCommand(RpcProtocol.CMD_REMOVE_DATANODE);
+
+		RpcResponseMessage.RemoveDataNodeRes removeDataNodeRes = new RpcResponseMessage.RemoveDataNodeRes();
+		DaRPCNameNodeResponse response = new DaRPCNameNodeResponse(removeDataNodeRes);
+		
+		DaRPCFuture<DaRPCNameNodeRequest, DaRPCNameNodeResponse> future = issueRPC(request, response);
+		
+		DaRPCNameNodeFuture<RpcRemoveDataNode> nameNodeFuture = new DaRPCNameNodeFuture<RpcRemoveDataNode>(future, removeDataNodeRes);
+		
+		return nameNodeFuture;
 	}
 	
 	@Override

--- a/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeRequest.java
+++ b/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeRequest.java
@@ -45,6 +45,7 @@ public class DaRPCNameNodeRequest implements DaRPCMessage {
 	private RpcRequestMessage.GetDataNodeReq getDataNodeReq;
 	private RpcRequestMessage.DumpNameNodeReq dumpNameNodeReq;
 	private RpcRequestMessage.PingNameNodeReq pingNameNodeReq;
+	private RpcRequestMessage.RemoveDataNodeReq removeDataNodeReq;
 
 	public DaRPCNameNodeRequest() {
 		this.cmd = 0;
@@ -60,6 +61,7 @@ public class DaRPCNameNodeRequest implements DaRPCMessage {
 		this.dumpNameNodeReq = new RpcRequestMessage.DumpNameNodeReq();
 		this.pingNameNodeReq = new RpcRequestMessage.PingNameNodeReq();
 		this.getDataNodeReq = new RpcRequestMessage.GetDataNodeReq();
+		this.removeDataNodeReq = new RpcRequestMessage.RemoveDataNodeReq();
 	}
 	
 	public DaRPCNameNodeRequest(RpcRequestMessage.CreateFileReq message) {
@@ -115,6 +117,11 @@ public class DaRPCNameNodeRequest implements DaRPCMessage {
 		this.type = message.getType();
 		this.pingNameNodeReq = message;
 	}
+
+	public DaRPCNameNodeRequest(RpcRequestMessage.RemoveDataNodeReq message) {
+		this.type = message.getType();
+		this.removeDataNodeReq = message;
+	}
 	
 	public void setCommand(short command) {
 		this.cmd = command;
@@ -163,6 +170,9 @@ public class DaRPCNameNodeRequest implements DaRPCMessage {
 		case RpcProtocol.REQ_PING_NAMENODE:
 			written += pingNameNodeReq.write(buffer);
 			break;
+		case RpcProtocol.REQ_REMOVE_DATANODE:
+			written += removeDataNodeReq.write(buffer);
+			break;
 		}
 		
 		return written;
@@ -205,6 +215,9 @@ public class DaRPCNameNodeRequest implements DaRPCMessage {
 			break;		
 		case RpcProtocol.REQ_PING_NAMENODE:
 			pingNameNodeReq.update(buffer);
+			break;
+		case RpcProtocol.REQ_REMOVE_DATANODE:
+			removeDataNodeReq.update(buffer);
 			break;
 		}
 	}
@@ -259,5 +272,9 @@ public class DaRPCNameNodeRequest implements DaRPCMessage {
 	
 	public RpcRequestMessage.PingNameNodeReq pingNameNode(){
 		return this.pingNameNodeReq;
+	}
+
+	public RpcRequestMessage.RemoveDataNodeReq removeDataNode(){
+		return this.removeDataNodeReq;
 	}
 }

--- a/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeRequest.java
+++ b/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeRequest.java
@@ -270,11 +270,11 @@ public class DaRPCNameNodeRequest implements DaRPCMessage {
 		return this.dumpNameNodeReq;
 	}
 	
-	public RpcRequestMessage.PingNameNodeReq pingNameNode(){
+	public RpcRequestMessage.PingNameNodeReq pingNameNode() {
 		return this.pingNameNodeReq;
 	}
 
-	public RpcRequestMessage.RemoveDataNodeReq removeDataNode(){
+	public RpcRequestMessage.RemoveDataNodeReq removeDataNode() {
 		return this.removeDataNodeReq;
 	}
 }

--- a/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeResponse.java
+++ b/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeResponse.java
@@ -40,6 +40,7 @@ public class DaRPCNameNodeResponse implements DaRPCMessage, RpcNameNodeState {
 	private RpcResponseMessage.GetLocationRes getLocationRes;	
 	private RpcResponseMessage.GetDataNodeRes getDataNodeRes;
 	private RpcResponseMessage.PingNameNodeRes pingNameNodeRes;
+	private RpcResponseMessage.RemoveDataNodeRes removeDataNodeRes;
 	
 	public DaRPCNameNodeResponse() {
 		this.type = 0;
@@ -54,6 +55,7 @@ public class DaRPCNameNodeResponse implements DaRPCMessage, RpcNameNodeState {
 		this.getLocationRes = new RpcResponseMessage.GetLocationRes();
 		this.getDataNodeRes = new RpcResponseMessage.GetDataNodeRes();
 		this.pingNameNodeRes = new RpcResponseMessage.PingNameNodeRes();
+		this.removeDataNodeRes = new RpcResponseMessage.RemoveDataNodeRes();
 	}
 	
 	public DaRPCNameNodeResponse(RpcResponseMessage.VoidRes message) {
@@ -99,6 +101,11 @@ public class DaRPCNameNodeResponse implements DaRPCMessage, RpcNameNodeState {
 	public DaRPCNameNodeResponse(RpcResponseMessage.PingNameNodeRes message) {
 		this.type = message.getType();
 		this.pingNameNodeRes = message;
+	}
+
+	public DaRPCNameNodeResponse(RpcResponseMessage.RemoveDataNodeRes message) {
+		this.type = message.getType();
+		this.removeDataNodeRes = message;
 	}
 	
 	public void setType(short type) throws Exception {
@@ -149,6 +156,11 @@ public class DaRPCNameNodeResponse implements DaRPCMessage, RpcNameNodeState {
 				throw new Exception("Response type not set");
 			}
 			break;
+		case RpcProtocol.RES_REMOVE_DATANODE:
+			if (removeDataNodeRes == null){
+				throw new Exception("Response type not set");
+			}
+			break;
 		}		
 	}	
 
@@ -188,7 +200,10 @@ public class DaRPCNameNodeResponse implements DaRPCMessage, RpcNameNodeState {
 			break;			
 		case RpcProtocol.RES_PING_NAMENODE:
 			written += pingNameNodeRes.write(buffer);
-			break;			
+			break;		
+		case RpcProtocol.RES_REMOVE_DATANODE:
+			written += removeDataNodeRes.write(buffer);
+			break;		
 		}
 		
 		return written;
@@ -234,6 +249,10 @@ public class DaRPCNameNodeResponse implements DaRPCMessage, RpcNameNodeState {
 		case RpcProtocol.RES_PING_NAMENODE:
 			pingNameNodeRes.update(buffer);
 			pingNameNodeRes.setError(error);
+			break;		
+		case RpcProtocol.RES_REMOVE_DATANODE:
+			removeDataNodeRes.update(buffer);
+			removeDataNodeRes.setError(error);
 			break;		
 		}
 	}
@@ -284,5 +303,9 @@ public class DaRPCNameNodeResponse implements DaRPCMessage, RpcNameNodeState {
 	
 	public RpcResponseMessage.PingNameNodeRes pingNameNode(){
 		return this.pingNameNodeRes;
+	}
+
+	public RpcResponseMessage.RemoveDataNodeRes removeDataNode(){
+		return this.removeDataNodeRes;
 	}
 }

--- a/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeResponse.java
+++ b/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCNameNodeResponse.java
@@ -301,11 +301,11 @@ public class DaRPCNameNodeResponse implements DaRPCMessage, RpcNameNodeState {
 		return getDataNodeRes;
 	}	
 	
-	public RpcResponseMessage.PingNameNodeRes pingNameNode(){
+	public RpcResponseMessage.PingNameNodeRes pingNameNode() {
 		return this.pingNameNodeRes;
 	}
 
-	public RpcResponseMessage.RemoveDataNodeRes removeDataNode(){
+	public RpcResponseMessage.RemoveDataNodeRes removeDataNode() {
 		return this.removeDataNodeRes;
 	}
 }

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeRequest.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeRequest.java
@@ -45,6 +45,7 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 	private RpcRequestMessage.GetDataNodeReq getDataNodeReq;
 	private RpcRequestMessage.DumpNameNodeReq dumpNameNodeReq;
 	private RpcRequestMessage.PingNameNodeReq pingNameNodeReq;
+	private RpcRequestMessage.RemoveDataNodeReq removeDataNodeReq;
 
 	public TcpNameNodeRequest() {
 		this.cmd = 0;
@@ -60,7 +61,8 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 		this.dumpNameNodeReq = new RpcRequestMessage.DumpNameNodeReq();
 		this.pingNameNodeReq = new RpcRequestMessage.PingNameNodeReq();
 		this.getDataNodeReq = new RpcRequestMessage.GetDataNodeReq();
-	}	
+		this.removeDataNodeReq = new RpcRequestMessage.RemoveDataNodeReq();
+	}
 	
 	public TcpNameNodeRequest(RpcRequestMessage.CreateFileReq message) {
 		this.type = message.getType();
@@ -115,7 +117,12 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 		this.type = message.getType();
 		this.pingNameNodeReq = message;
 	}
-	
+
+	public TcpNameNodeRequest(RpcRequestMessage.RemoveDataNodeReq message) {
+		this.type = message.getType();
+		this.removeDataNodeReq = message;
+	}
+
 	public void setCommand(short command) {
 		this.cmd = command;
 	}	
@@ -163,6 +170,9 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 		case RpcProtocol.REQ_PING_NAMENODE:
 			written += pingNameNodeReq.write(buffer);
 			break;
+		case RpcProtocol.REQ_REMOVE_DATANODE:
+			written += removeDataNodeReq.write(buffer);
+			break;
 		}
 		
 		return written;
@@ -205,6 +215,9 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 			break;		
 		case RpcProtocol.REQ_PING_NAMENODE:
 			pingNameNodeReq.update(buffer);
+			break;
+		case RpcProtocol.REQ_REMOVE_DATANODE:
+			removeDataNodeReq.update(buffer);
 			break;
 		}
 	}
@@ -259,5 +272,9 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 	
 	public RpcRequestMessage.PingNameNodeReq pingNameNode(){
 		return this.pingNameNodeReq;
+	}
+
+	public RpcRequestMessage.RemoveDataNodeReq removeDataNode(){
+		return this.removeDataNodeReq;
 	}
 }

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeRequest.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeRequest.java
@@ -270,11 +270,11 @@ public class TcpNameNodeRequest extends RpcRequestMessage implements NaRPCMessag
 		return this.dumpNameNodeReq;
 	}
 	
-	public RpcRequestMessage.PingNameNodeReq pingNameNode(){
+	public RpcRequestMessage.PingNameNodeReq pingNameNode() {
 		return this.pingNameNodeReq;
 	}
 
-	public RpcRequestMessage.RemoveDataNodeReq removeDataNode(){
+	public RpcRequestMessage.RemoveDataNodeReq removeDataNode() {
 		return this.removeDataNodeReq;
 	}
 }

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeResponse.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeResponse.java
@@ -43,6 +43,7 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 	private RpcResponseMessage.GetLocationRes getLocationRes;	
 	private RpcResponseMessage.GetDataNodeRes getDataNodeRes;
 	private RpcResponseMessage.PingNameNodeRes pingNameNodeRes;
+	private RpcResponseMessage.RemoveDataNodeRes removeDataNodeRes;
 	
 	public TcpNameNodeResponse() {
 		this.type = 0;
@@ -56,6 +57,7 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 		this.getLocationRes = new RpcResponseMessage.GetLocationRes();
 		this.getDataNodeRes = new RpcResponseMessage.GetDataNodeRes();
 		this.pingNameNodeRes = new RpcResponseMessage.PingNameNodeRes();
+		this.removeDataNodeRes = new RpcResponseMessage.RemoveDataNodeRes();
 	}
 	
 	public TcpNameNodeResponse(RpcResponseMessage.VoidRes message) {
@@ -102,6 +104,11 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 		this.type = message.getType();
 		this.pingNameNodeRes = message;
 	}
+
+	public TcpNameNodeResponse(RpcResponseMessage.RemoveDataNodeRes message) {
+		this.type = message.getType();
+		this.removeDataNodeRes = message;
+	}
 	
 	public void setType(short type) throws Exception {
 		this.type = type;
@@ -143,7 +150,10 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 			break;			
 		case RpcProtocol.RES_PING_NAMENODE:
 			written += pingNameNodeRes.write(buffer);
-			break;			
+			break;
+		case RpcProtocol.RES_REMOVE_DATANODE:
+			written += removeDataNodeRes.write(buffer);
+			break;
 		}
 		
 		return written;
@@ -189,7 +199,11 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 		case RpcProtocol.RES_PING_NAMENODE:
 			pingNameNodeRes.update(buffer);
 			pingNameNodeRes.setError(error);
-			break;		
+			break;
+		case RpcProtocol.RES_REMOVE_DATANODE:
+			removeDataNodeRes.update(buffer);
+			removeDataNodeRes.setError(error);
+			break;
 		}
 	}
 	
@@ -239,5 +253,9 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 	
 	public RpcResponseMessage.PingNameNodeRes pingNameNode(){
 		return this.pingNameNodeRes;
+	}
+
+	public RpcResponseMessage.RemoveDataNodeRes removeDataNode(){
+		return this.removeDataNodeRes;
 	}
 }

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeResponse.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpNameNodeResponse.java
@@ -250,12 +250,12 @@ public class TcpNameNodeResponse extends RpcResponseMessage implements RpcNameNo
 	public RpcResponseMessage.GetDataNodeRes getDataNode() {
 		return getDataNodeRes;
 	}	
-	
-	public RpcResponseMessage.PingNameNodeRes pingNameNode(){
+
+	public RpcResponseMessage.PingNameNodeRes pingNameNode() {
 		return this.pingNameNodeRes;
 	}
 
-	public RpcResponseMessage.RemoveDataNodeRes removeDataNode(){
+	public RpcResponseMessage.RemoveDataNodeRes removeDataNode() {
 		return this.removeDataNodeRes;
 	}
 }

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcConnection.java
@@ -31,6 +31,7 @@ import org.apache.crail.utils.CrailUtils;
 import org.slf4j.Logger;
 
 import java.io.IOException;
+import java.net.InetAddress;
 
 public class TcpRpcConnection implements RpcConnection {
 	static private final Logger LOG = CrailUtils.getLogger();
@@ -182,6 +183,17 @@ public class TcpRpcConnection implements RpcConnection {
 		request.setCommand(RpcProtocol.CMD_PING_NAMENODE);
 		NaRPCFuture<TcpNameNodeRequest, TcpNameNodeResponse> future = endpoint.issueRequest(request, response);
 		return new TcpFuture<RpcPing>(future, resp);
+	}
+
+	public RpcFuture<RpcRemoveDataNode> removeDataNode(InetAddress addr, int port) throws Exception {
+		RpcRequestMessage.RemoveDataNodeReq req = new RpcRequestMessage.RemoveDataNodeReq(addr, port);
+		RpcResponseMessage.RemoveDataNodeRes resp = new RpcResponseMessage.RemoveDataNodeRes();
+
+		TcpNameNodeRequest request = new TcpNameNodeRequest(req);
+		TcpNameNodeResponse response = new TcpNameNodeResponse(resp);
+		request.setCommand(RpcProtocol.CMD_REMOVE_DATANODE);
+		NaRPCFuture<TcpNameNodeRequest, TcpNameNodeResponse> future = endpoint.issueRequest(request, response);
+		return new TcpFuture<RpcRemoveDataNode>(future, resp);
 	}
 
 }

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcProtocol.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcProtocol.java
@@ -40,6 +40,7 @@ public class RpcProtocol extends RpcErrors {
 	public static final short CMD_DUMP_NAMENODE = 10;
 	public static final short CMD_PING_NAMENODE = 11;
 	public static final short CMD_GET_DATANODE = 12;
+	public static final short CMD_REMOVE_DATANODE = 13;
 	
 	//request types
 	public static final short REQ_CREATE_FILE = 1;	
@@ -53,7 +54,8 @@ public class RpcProtocol extends RpcErrors {
 	public static final short REQ_DUMP_NAMENODE = 10;
 	public static final short REQ_PING_NAMENODE = 11;
 	public static final short REQ_GET_DATANODE = 12;
-	
+	public static final short REQ_REMOVE_DATANODE = 13;
+
 	//response types
 	public static final short RES_VOID = 1;
 	public static final short RES_CREATE_FILE = 2;
@@ -64,6 +66,7 @@ public class RpcProtocol extends RpcErrors {
 	public static final short RES_GET_LOCATION = 7;
 	public static final short RES_PING_NAMENODE = 9;
 	public static final short RES_GET_DATANODE = 10;
+	public static final short RES_REMOVE_DATANODE = 11;
 	
 	
 	static {
@@ -79,6 +82,7 @@ public class RpcProtocol extends RpcErrors {
 		requestTypes[CMD_DUMP_NAMENODE] = REQ_DUMP_NAMENODE;
 		requestTypes[CMD_PING_NAMENODE] = REQ_PING_NAMENODE;	
 		requestTypes[CMD_GET_DATANODE] = REQ_GET_DATANODE;
+		requestTypes[CMD_REMOVE_DATANODE] = REQ_REMOVE_DATANODE;
 		
 		responseTypes[0] = 0;
 		responseTypes[CMD_CREATE_FILE] = RES_CREATE_FILE;
@@ -92,6 +96,7 @@ public class RpcProtocol extends RpcErrors {
 		responseTypes[CMD_DUMP_NAMENODE] = RES_VOID;
 		responseTypes[CMD_PING_NAMENODE] = RES_PING_NAMENODE;	
 		responseTypes[CMD_GET_DATANODE] = RES_GET_DATANODE;
+		responseTypes[CMD_REMOVE_DATANODE] = RES_REMOVE_DATANODE;
 	}
 	
 

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcRequestMessage.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcRequestMessage.java
@@ -579,12 +579,12 @@ public class RpcRequestMessage {
 		private InetAddress ipAddr;
 		private int port;
 
-		public RemoveDataNodeReq(){
+		public RemoveDataNodeReq() {
 			this.ipAddr = null;
 			this.port = 0;
 		}
 
-		public RemoveDataNodeReq(InetAddress addr, int port){
+		public RemoveDataNodeReq(InetAddress addr, int port) {
 			this.ipAddr = addr;
 			this.port = port;
 		}
@@ -594,7 +594,7 @@ public class RpcRequestMessage {
 			return 4 + Integer.BYTES;
 		}
 
-		public short getType(){
+		public short getType() {
 			return RpcProtocol.REQ_REMOVE_DATANODE;
 		}
 
@@ -622,11 +622,11 @@ public class RpcRequestMessage {
 			this.port = buffer.getInt();
 		}
 
-		public InetAddress getIPAddress(){
+		public InetAddress getIPAddress() {
 			return this.ipAddr;
 		}
 
-		public int port(){
+		public int port() {
 			return this.port;
 		}
 	}

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcRequestMessage.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcRequestMessage.java
@@ -18,6 +18,8 @@
 
 package org.apache.crail.rpc;
 
+import java.io.IOException;
+import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 
@@ -571,7 +573,63 @@ public class RpcRequestMessage {
 		public void update(ByteBuffer buffer) {
 			op = buffer.getInt();
 		}		
-	}	
+	}
+
+	public static class RemoveDataNodeReq implements RpcProtocol.NameNodeRpcMessage {
+		private InetAddress ipAddr;
+		private int port;
+
+		public RemoveDataNodeReq(){
+			this.ipAddr = null;
+			this.port = 0;
+		}
+
+		public RemoveDataNodeReq(InetAddress addr, int port){
+			this.ipAddr = addr;
+			this.port = port;
+		}
+
+		public int size() {
+			//  sizeof(ip-addr) + sizeof(port)
+			return 4 + Integer.BYTES;
+		}
+
+		public short getType(){
+			return RpcProtocol.REQ_REMOVE_DATANODE;
+		}
+
+		public int write(ByteBuffer buffer) throws IOException {
+			int size = size();
+
+			checkSize(buffer.remaining());
+
+			buffer.put(this.getIPAddress().getAddress());
+			buffer.putInt(this.port());
+			return size;
+		}
+
+		private void checkSize(int remaining) throws IOException {
+			if(this.size() > remaining)
+				throw new IOException("Only " + remaining + " remaining bytes stored in buffer, however " + this.size() + " bytes are required");
+		}
+
+		public void update(ByteBuffer buffer) throws IOException {
+			checkSize(buffer.remaining());
+
+			byte[] b = new byte[4];
+			buffer.get(b);
+			this.ipAddr = InetAddress.getByAddress(b);
+			this.port = buffer.getInt();
+		}
+
+		public InetAddress getIPAddress(){
+			return this.ipAddr;
+		}
+
+		public int port(){
+			return this.port;
+		}
+	}
 	
 
 }

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
@@ -598,6 +598,10 @@ public class RpcResponseMessage {
 		public void setFreeBlockCount(int blockCount) {
 			this.statistics.setFreeBlockCount(blockCount);
 		}
+
+		public void setStatus(short status) {
+			this.statistics.setStatus(status);
+		}
 		
 		public short getError(){
 			return 0;
@@ -641,6 +645,51 @@ public class RpcResponseMessage {
 		}
 		
 		public void setData(int data){
+			this.data = data;
+		}
+
+		public short getError(){
+			return error;
+		}
+
+		public void setError(short error) {
+			this.error = error;
+		}
+	}
+
+	public static class RemoveDataNodeRes implements RpcProtocol.NameNodeRpcMessage, RpcRemoveDataNode {
+		public static int CSIZE = Short.BYTES;
+
+		private short data;
+		private short error;
+
+		public RemoveDataNodeRes() {
+			this.data = 0;
+			this.error = 0;
+		}
+
+		public int size() {
+			return CSIZE;
+		}
+
+		public short getType(){
+			return RpcProtocol.RES_REMOVE_DATANODE;
+		}
+
+		public int write(ByteBuffer buffer) {
+			buffer.putShort(data);
+			return CSIZE;
+		}
+
+		public void update(ByteBuffer buffer) {
+			data = buffer.getShort();
+		}
+
+		public short getData(){
+			return data;
+		}
+
+		public void setData(short data) {
 			this.data = data;
 		}
 

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcResponseMessage.java
@@ -660,11 +660,11 @@ public class RpcResponseMessage {
 	public static class RemoveDataNodeRes implements RpcProtocol.NameNodeRpcMessage, RpcRemoveDataNode {
 		public static int CSIZE = Short.BYTES;
 
-		private short data;
+		private short rpcStatus;
 		private short error;
 
 		public RemoveDataNodeRes() {
-			this.data = 0;
+			this.rpcStatus = 0;
 			this.error = 0;
 		}
 
@@ -672,28 +672,28 @@ public class RpcResponseMessage {
 			return CSIZE;
 		}
 
-		public short getType(){
+		public short getType() {
 			return RpcProtocol.RES_REMOVE_DATANODE;
 		}
 
 		public int write(ByteBuffer buffer) {
-			buffer.putShort(data);
+			buffer.putShort(rpcStatus);
 			return CSIZE;
 		}
 
 		public void update(ByteBuffer buffer) {
-			data = buffer.getShort();
+			rpcStatus = buffer.getShort();
 		}
 
-		public short getData(){
-			return data;
+		public short getRpcStatus() {
+			return rpcStatus;
 		}
 
-		public void setData(short data) {
-			this.data = data;
+		public void setRpcStatus(short rpcStatus) {
+			this.rpcStatus = rpcStatus;
 		}
 
-		public short getError(){
+		public short getError() {
 			return error;
 		}
 


### PR DESCRIPTION
This PR is the first of three planned PRs for implementing resource elasticity within Crail. More specifically, the goal is to allow to automatically and dynamically adapt the number of running datanodes based on different possible parameters (e.g. resource consumption, available storage capacities, ...). This requires support for starting and terminating running datanodes automatically. This functionality will be implemented mostly within the Crail namenode. Therefore, the Crail namenode will not only maintain information on the current state of the datanodes and the deployment but will also start or terminate datanodes as required. For deciding how to adjust the number of datanodes  based on the current state observed in the Crail namenode so-called _policies_ are used. 

The following changes will be included within the seperate PRs:

1) This first PR implements a new RPC (for both darpc and narpc) that allows to specify a datanode (using IP-address and port number) that should be shutdown. Additionally, a `status` field is added to `DataNodeStatistics`. This will be used in the `getDataNode` RPC to allow the namenode to inform a datanode that it can safely shutdown.

2) The seconds PR will implement the actual mechanism for shutting down a datanode.

3) The third PR implements a simple policy for implementing elasticity based on the system's storage consumption.