### PR TITLE
Resource Elasticity [2/3]

### DIFF
--- a/bin/crail
+++ b/bin/crail
@@ -27,6 +27,7 @@ function print_usage(){
   echo "       where COMMAND is one of:"
   echo "  namenode             run the Crail namenode"
   echo "  datanode             run a Crail datanode"
+  echo "  removeDatanode       remove a Crail datanode"
   echo "  fsck                 run a Crail file check command"
   echo "  fs                   run a Crail shell command"
   echo "  iobench              run a Crail benchmark/test"
@@ -53,6 +54,8 @@ if [ "$COMMAND" = "namenode" ] ; then
   CLASS=org.apache.crail.namenode.NameNode
 elif [ "$COMMAND" = "datanode" ] ; then
   CLASS=org.apache.crail.storage.StorageServer
+elif [ "$COMMAND" = "removeDatanode" ] ; then
+  CLASS=org.apache.crail.tools.RemoveDataNode
 elif [ "$COMMAND" = "fsck" ] ; then
   CLASS=org.apache.crail.tools.CrailFsck
 elif [ "$COMMAND" = "fs" ] ; then

--- a/client/src/main/java/org/apache/crail/tools/RemoveDataNode.java
+++ b/client/src/main/java/org/apache/crail/tools/RemoveDataNode.java
@@ -1,0 +1,87 @@
+package org.apache.crail.tools;
+
+import org.apache.commons.cli.*;
+import org.apache.crail.conf.CrailConfiguration;
+import org.apache.crail.conf.CrailConstants;
+import org.apache.crail.rpc.*;
+import org.apache.crail.utils.CrailUtils;
+import org.slf4j.Logger;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
+
+public class RemoveDataNode {
+
+    RemoveDataNode() {}
+
+    public static void main(String[] args) throws Exception {
+
+        InetAddress ipaddr = null;
+        int port = -1;
+
+        Option ipOption = Option.builder("i").desc("Ip address").hasArg().build();
+        Option portOption = Option.builder("p").desc("port").hasArg().build();
+
+        Options options = new Options();
+        options.addOption(ipOption);
+        options.addOption(portOption);
+
+        CommandLineParser parser = new DefaultParser();
+        CommandLine line = parser.parse(options, Arrays.copyOfRange(args, 0, args.length));
+
+        if(line.hasOption(ipOption.getOpt())) {
+            ipaddr = InetAddress.getByName(line.getOptionValue(ipOption.getOpt()));
+        } else {
+            throw new Exception("Missing Ip-Address specification");
+        }
+
+        if(line.hasOption(portOption.getOpt())) {
+            port = Integer.parseInt(line.getOptionValue(portOption.getOpt()));
+        } else {
+            throw new Exception("Missing port specification");
+        }
+
+        Logger LOG = CrailUtils.getLogger();
+        CrailConfiguration conf = CrailConfiguration.createConfigurationFromFile();
+        CrailConstants.updateConstants(conf);
+        CrailConstants.printConf();
+        CrailConstants.verify();
+        RpcClient rpcClient = RpcClient.createInstance(CrailConstants.NAMENODE_RPC_TYPE);
+
+        rpcClient.init(conf, null);
+        rpcClient.printConf(LOG);
+
+        ConcurrentLinkedQueue<InetSocketAddress> namenodeList = CrailUtils.getNameNodeList();
+        ConcurrentLinkedQueue<RpcConnection> connectionList = new ConcurrentLinkedQueue<RpcConnection>();
+        while(!namenodeList.isEmpty()){
+            InetSocketAddress address = namenodeList.poll();
+            RpcConnection connection = rpcClient.connect(address);
+            connectionList.add(connection);
+        }
+        RpcConnection rpcConnection = connectionList.peek();
+        if (connectionList.size() > 1){
+            rpcConnection = new RpcDispatcher(connectionList);
+        }
+        LOG.info("connected to namenode(s) " + rpcConnection.toString());
+
+        LOG.info("Trying to remove datanode at " + ipaddr.getHostName() + ":" + port);
+
+        Future<RpcRemoveDataNode> res = rpcConnection.removeDataNode(ipaddr, port);
+        short response = res.get().getData();
+
+        rpcConnection.close();
+
+        if(response == RpcErrors.ERR_DATANODE_NOT_REGISTERED) {
+            LOG.info("Datanode running at " + ipaddr.getHostAddress() + ":" + port + " is not registered at NameNode");
+        } else if(response == RpcErrors.ERR_OK) {
+            LOG.info("Datanode running at " + ipaddr.getHostAddress() + ":" + port + " was scheduled for removal");
+        } else {
+            throw new Exception("Unexpected error code in RPC response");
+        }
+
+
+    }
+}

--- a/client/src/main/java/org/apache/crail/tools/RemoveDataNode.java
+++ b/client/src/main/java/org/apache/crail/tools/RemoveDataNode.java
@@ -36,6 +36,7 @@ public class RemoveDataNode {
             port = Integer.parseInt(line.getOptionValue(portOption.getOpt()));
         } catch(Exception e) {
             formatter.printHelp("RemoveDataNode", options);
+            System.exit(-1);
         }
 
         Logger LOG = CrailUtils.getLogger();

--- a/client/src/main/java/org/apache/crail/tools/RemoveDataNode.java
+++ b/client/src/main/java/org/apache/crail/tools/RemoveDataNode.java
@@ -15,33 +15,27 @@ import java.util.concurrent.Future;
 
 public class RemoveDataNode {
 
-    RemoveDataNode() {}
-
     public static void main(String[] args) throws Exception {
 
         InetAddress ipaddr = null;
         int port = -1;
 
-        Option ipOption = Option.builder("i").desc("Ip address").hasArg().build();
-        Option portOption = Option.builder("p").desc("port").hasArg().build();
+        Option ipOption = Option.builder("i").desc("Ip address").hasArg().required().build();
+        Option portOption = Option.builder("p").desc("port").hasArg().required().build();
 
         Options options = new Options();
         options.addOption(ipOption);
         options.addOption(portOption);
 
+        HelpFormatter formatter = new HelpFormatter();
         CommandLineParser parser = new DefaultParser();
-        CommandLine line = parser.parse(options, Arrays.copyOfRange(args, 0, args.length));
+        CommandLine line = parser.parse(options, args);
 
-        if(line.hasOption(ipOption.getOpt())) {
+        try {
             ipaddr = InetAddress.getByName(line.getOptionValue(ipOption.getOpt()));
-        } else {
-            throw new Exception("Missing Ip-Address specification");
-        }
-
-        if(line.hasOption(portOption.getOpt())) {
             port = Integer.parseInt(line.getOptionValue(portOption.getOpt()));
-        } else {
-            throw new Exception("Missing port specification");
+        } catch(Exception e) {
+            formatter.printHelp("RemoveDataNode", options);
         }
 
         Logger LOG = CrailUtils.getLogger();

--- a/client/src/main/java/org/apache/crail/tools/RemoveDataNode.java
+++ b/client/src/main/java/org/apache/crail/tools/RemoveDataNode.java
@@ -70,7 +70,7 @@ public class RemoveDataNode {
         LOG.info("Trying to remove datanode at " + ipaddr.getHostName() + ":" + port);
 
         Future<RpcRemoveDataNode> res = rpcConnection.removeDataNode(ipaddr, port);
-        short response = res.get().getData();
+        short response = res.get().getRpcStatus();
 
         rpcConnection.close();
 

--- a/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
@@ -195,31 +195,33 @@ class StorageClass {
 	}
 
 	short prepareForRemovalDatanode(DataNodeInfo dn) throws IOException {
-		// this will only mark it for removal
-		return prepareOrRemoveDN(dn, true);
-	}
 
-	short removeDatanode(DataNodeInfo dn) throws IOException {
-		// this will remove it as well
-		return prepareOrRemoveDN(dn, false);
-	}
-
-	//---------------
-
-	private short prepareOrRemoveDN(DataNodeInfo dn, boolean onlyMark) throws IOException {
+		// this will only mark the datanode for removal
 		DataNodeBlocks toBeRemoved = membership.get(dn.key());
 		if (toBeRemoved == null) {
 			LOG.error("DataNode: " + dn.toString() + " not found");
 			return RpcErrors.ERR_DATANODE_NOT_REGISTERED;
 		} else {
-			if (onlyMark) {
-				toBeRemoved.scheduleForRemoval();
-			} else {
-				membership.remove(toBeRemoved.key());
-			}
+			toBeRemoved.scheduleForRemoval();
+			return RpcErrors.ERR_OK;
 		}
-		return RpcErrors.ERR_OK;
 	}
+
+	short removeDatanode(DataNodeInfo dn) throws IOException {
+
+		// this will remove the datanode once it does not store any remaining data blocks
+		DataNodeBlocks toBeRemoved = membership.get(dn.key());
+		if (toBeRemoved == null) {
+			LOG.error("DataNode: " + dn.toString() + " not found");
+			return RpcErrors.ERR_DATANODE_NOT_REGISTERED;
+		} else {
+			membership.remove(toBeRemoved.key());
+			return RpcErrors.ERR_OK;
+		}
+	}
+
+	//---------------
+
 
 	private void _addDataNode(DataNodeBlocks dataNode){
 		LOG.info("adding datanode " + CrailUtils.getIPAddressFromBytes(dataNode.getIpAddress()) + ":" + dataNode.getPort() + " of type " + dataNode.getStorageType() + " to storage class " + storageClass);

--- a/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.crail.namenode;
 
+import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
@@ -85,12 +86,12 @@ public class BlockStore {
 		return storageClasses[storageClass].getDataNode(dnInfo);
 	}
 
-	short removeDataNode(DataNodeInfo dn) throws Exception {
+	short removeDataNode(DataNodeInfo dn) throws IOException {
 		int storageClass = dn.getStorageClass();
 		return storageClasses[storageClass].removeDatanode(dn);
 	}
 
-	short prepareDataNodeForRemoval(DataNodeInfo dn) throws Exception {
+	short prepareDataNodeForRemoval(DataNodeInfo dn) throws IOException {
 
 		// Despite several potential storageClasses the pair (Ip-addr,port) should
 		// nevertheless target only one running datanode instance.
@@ -193,28 +194,29 @@ class StorageClass {
 
 	}
 
-	short prepareForRemovalDatanode(DataNodeInfo dn) throws Exception {
+	short prepareForRemovalDatanode(DataNodeInfo dn) throws IOException {
 		// this will only mark it for removal
 		return prepareOrRemoveDN(dn, true);
 	}
 
-	short removeDatanode(DataNodeInfo dn) throws Exception {
+	short removeDatanode(DataNodeInfo dn) throws IOException {
 		// this will remove it as well
 		return prepareOrRemoveDN(dn, false);
 	}
 
 	//---------------
 
-	private short prepareOrRemoveDN(DataNodeInfo dn, boolean onlyMark) throws Exception {
+	private short prepareOrRemoveDN(DataNodeInfo dn, boolean onlyMark) throws IOException {
 		DataNodeBlocks toBeRemoved = membership.get(dn.key());
 		if (toBeRemoved == null) {
 			LOG.error("DataNode: " + dn.toString() + " not found");
 			return RpcErrors.ERR_DATANODE_NOT_REGISTERED;
 		} else {
-			if (onlyMark)
+			if (onlyMark) {
 				toBeRemoved.scheduleForRemoval();
-			else
+			} else {
 				membership.remove(toBeRemoved.key());
+			}
 		}
 		return RpcErrors.ERR_OK;
 	}

--- a/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
@@ -195,17 +195,17 @@ class StorageClass {
 
 	short prepareForRemovalDatanode(DataNodeInfo dn) throws Exception {
 		// this will only mark it for removal
-		return _prepareOrRemoveDN(dn, true);
+		return prepareOrRemoveDN(dn, true);
 	}
 
 	short removeDatanode(DataNodeInfo dn) throws Exception {
 		// this will remove it as well
-		return _prepareOrRemoveDN(dn, false);
+		return prepareOrRemoveDN(dn, false);
 	}
 
 	//---------------
 
-	private short _prepareOrRemoveDN(DataNodeInfo dn, boolean onlyMark) throws Exception {
+	private short prepareOrRemoveDN(DataNodeInfo dn, boolean onlyMark) throws Exception {
 		DataNodeBlocks toBeRemoved = membership.get(dn.key());
 		if (toBeRemoved == null) {
 			LOG.error("DataNode: " + dn.toString() + " not found");

--- a/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
@@ -58,8 +58,9 @@ public class DataNodeBlocks extends DataNodeInfo {
 		// are added in the form of free blocks. By keeping track of this number (which grows block for block), we
 		// learn the maximum available capacity in this datanode. Only when the number of free blocks equals the number
 		// of all blocks, the datanode is safe to be removed.
-		if(freeBlocks.size() > this.maxBlockCount)
+		if(freeBlocks.size() > this.maxBlockCount) {
 			this.maxBlockCount = freeBlocks.size();
+		}
 	}
 	
 	public void addFreeBlock(NameNodeBlockInfo nnBlock) {

--- a/namenode/src/main/java/org/apache/crail/namenode/LogDispatcher.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/LogDispatcher.java
@@ -28,6 +28,7 @@ import org.apache.crail.rpc.RpcRequestMessage.GetDataNodeReq;
 import org.apache.crail.rpc.RpcRequestMessage.GetFileReq;
 import org.apache.crail.rpc.RpcRequestMessage.GetLocationReq;
 import org.apache.crail.rpc.RpcRequestMessage.PingNameNodeReq;
+import org.apache.crail.rpc.RpcRequestMessage.RemoveDataNodeReq;
 import org.apache.crail.rpc.RpcRequestMessage.RemoveFileReq;
 import org.apache.crail.rpc.RpcRequestMessage.RenameFileReq;
 import org.apache.crail.rpc.RpcRequestMessage.SetBlockReq;
@@ -39,6 +40,7 @@ import org.apache.crail.rpc.RpcResponseMessage.GetDataNodeRes;
 import org.apache.crail.rpc.RpcResponseMessage.GetFileRes;
 import org.apache.crail.rpc.RpcResponseMessage.GetLocationRes;
 import org.apache.crail.rpc.RpcResponseMessage.PingNameNodeRes;
+import org.apache.crail.rpc.RpcResponseMessage.RemoveDataNodeRes;
 import org.apache.crail.rpc.RpcResponseMessage.RenameRes;
 import org.apache.crail.rpc.RpcResponseMessage.VoidRes;
 
@@ -135,5 +137,11 @@ public class LogDispatcher implements RpcNameNodeService {
 			RpcNameNodeState errorState) throws Exception {
 		return service.ping(request, response, errorState);
 	}
-	
+
+	@Override
+	public short removeDataNode(RemoveDataNodeReq request, RemoveDataNodeRes response,
+			RpcNameNodeState errorState) throws Exception {
+		return service.removeDataNode(request, response, errorState);
+	}
+
 }

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -412,7 +412,18 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		if (dnInfoNn == null){
 			return RpcErrors.ERR_DATANODE_NOT_REGISTERED;
 		}
-		
+
+		if(dnInfoNn.isScheduleForRemoval()){
+			// verify that datanode does not store any remaining blocks
+			if(dnInfoNn.safeForRemoval()){
+				// remove datanode from internal datastructures and prepare response
+				blockStore.removeDataNode(dnInfo);
+				response.setServiceId(serviceId);
+				response.setStatus(RpcErrors.ERR_DATANODE_STOP);
+				return RpcErrors.ERR_OK;
+			}
+		}
+
 		dnInfoNn.touch();
 		response.setServiceId(serviceId);
 		response.setFreeBlockCount(dnInfoNn.getBlockCount());
@@ -570,10 +581,26 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		
 		return RpcErrors.ERR_OK;
 	}
-	
+
+	@Override
+	public short removeDataNode(RpcRequestMessage.RemoveDataNodeReq request, RpcResponseMessage.RemoveDataNodeRes response, RpcNameNodeState errorState) throws Exception {
+
+		DataNodeInfo dn_info = new DataNodeInfo(0,0,0,request.getIPAddress().getAddress(), request.port());
+
+		short res = prepareDataNodeForRemoval(dn_info);
+		response.setData(res);
+
+		return RpcErrors.ERR_OK;
+	}
+
 	
 	//--------------- helper functions
-	
+
+	public short prepareDataNodeForRemoval(DataNodeInfo dn) throws Exception {
+		LOG.info("Removing data node: " + dn);
+		return blockStore.prepareDataNodeForRemoval(dn);
+	}
+
 	void appendToDeleteQueue(AbstractNode fileInfo) throws Exception {
 		if (fileInfo != null) {
 			fileInfo.setDelay(CrailConstants.TOKEN_EXPIRATION);

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -27,10 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.crail.CrailNodeType;
 import org.apache.crail.conf.CrailConstants;
-import org.apache.crail.metadata.BlockInfo;
-import org.apache.crail.metadata.DataNodeInfo;
-import org.apache.crail.metadata.FileInfo;
-import org.apache.crail.metadata.FileName;
+import org.apache.crail.metadata.*;
 import org.apache.crail.rpc.RpcErrors;
 import org.apache.crail.rpc.RpcNameNodeService;
 import org.apache.crail.rpc.RpcNameNodeState;
@@ -419,7 +416,7 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 				// remove datanode from internal datastructures and prepare response
 				blockStore.removeDataNode(dnInfo);
 				response.setServiceId(serviceId);
-				response.setStatus(RpcErrors.ERR_DATANODE_STOP);
+				response.setStatus(DataNodeStatus.STATUS_DATANODE_STOP);
 				return RpcErrors.ERR_OK;
 			}
 		}
@@ -588,7 +585,7 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		DataNodeInfo dn_info = new DataNodeInfo(0,0,0,request.getIPAddress().getAddress(), request.port());
 
 		short res = prepareDataNodeForRemoval(dn_info);
-		response.setData(res);
+		response.setRpcStatus(res);
 
 		return RpcErrors.ERR_OK;
 	}

--- a/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCServiceDispatcher.java
+++ b/rpc-darpc/src/main/java/org/apache/crail/namenode/rpc/darpc/DaRPCServiceDispatcher.java
@@ -119,6 +119,9 @@ public class DaRPCServiceDispatcher extends DaRPCNameNodeProtocol implements DaR
 				error = this.stats(request.pingNameNode(), response.pingNameNode(), response);
 				error = service.ping(request.pingNameNode(), response.pingNameNode(), response);
 				break;
+			case RpcProtocol.CMD_REMOVE_DATANODE:
+				error = service.removeDataNode(request.removeDataNode(), response.removeDataNode(), response);
+				break;
 			default:
 				error = RpcErrors.ERR_INVALID_RPC_CMD;
 				LOG.info("Rpc command not valid, opcode " + request.getCmd());

--- a/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcDispatcher.java
+++ b/rpc-narpc/src/main/java/org/apache/crail/namenode/rpc/tcp/TcpRpcDispatcher.java
@@ -81,6 +81,9 @@ public class TcpRpcDispatcher implements NaRPCService<TcpNameNodeRequest, TcpNam
 			case RpcProtocol.CMD_PING_NAMENODE:
 				error = service.ping(request.pingNameNode(), response.pingNameNode(), response);
 				break;
+			case RpcProtocol.CMD_REMOVE_DATANODE:
+				error = service.removeDataNode(request.removeDataNode(), response.removeDataNode(), response);
+				break;
 			default:
 				error = RpcErrors.ERR_INVALID_RPC_CMD;
 				LOG.info("Rpc command not valid, opcode " + request.getCmd());

--- a/rpc/src/main/java/org/apache/crail/rpc/RpcNameNodeService.java
+++ b/rpc/src/main/java/org/apache/crail/rpc/RpcNameNodeService.java
@@ -65,7 +65,10 @@ public interface RpcNameNodeService {
 	public abstract short ping(RpcRequestMessage.PingNameNodeReq request,
 			RpcResponseMessage.PingNameNodeRes response, RpcNameNodeState errorState)
 			throws Exception;
-	
+
+	public abstract short removeDataNode(RpcRequestMessage.RemoveDataNodeReq request,
+			 RpcResponseMessage.RemoveDataNodeRes response, RpcNameNodeState errorState) throws Exception;
+
 	@SuppressWarnings("unchecked")
 	public static RpcNameNodeService createInstance(String name) throws Exception {
 		Class<?> serviceClass = Class.forName(name);

--- a/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
+++ b/storage-narpc/src/main/java/org/apache/crail/storage/tcp/TcpStorageServer.java
@@ -101,6 +101,20 @@ public class TcpStorageServer implements Runnable, StorageServer, NaRPCService<T
 	}
 
 	@Override
+	public void prepareToShutDown(){
+
+		LOG.info("Preparing TCP-Storage server for shutdown");
+		this.alive = false;
+		
+		try {
+			serverEndpoint.close();
+			serverGroup.close();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	@Override
 	public void run() {
 		try {
 			LOG.info("running TCP storage server, address " + address);
@@ -110,7 +124,11 @@ public class TcpStorageServer implements Runnable, StorageServer, NaRPCService<T
 				LOG.info("new connection " + endpoint.address());
 			}
 		} catch(Exception e){
-			e.printStackTrace();
+			// if StorageServer is still marked as running output stacktrace
+			// otherwise this is expected behaviour
+			if(this.alive) {
+				e.printStackTrace();
+			}
 		}
 	}
 

--- a/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageServer.java
+++ b/storage-nvmf/src/main/java/org/apache/crail/storage/nvmf/NvmfStorageServer.java
@@ -96,8 +96,11 @@ public class NvmfStorageServer implements StorageServer {
 				Thread.sleep(NvmfStorageConstants.KEEP_ALIVE_INTERVAL_MS);
 				controller.keepAlive();
 			} catch (Exception e) {
-				e.printStackTrace();
-				isAlive = false;
+				// if StorageServer is still marked as running output stacktrace
+				// otherwise this is expected behaviour
+				if(this.isAlive){
+					e.printStackTrace();
+				}
 			}
 		}
 	}
@@ -125,5 +128,19 @@ public class NvmfStorageServer implements StorageServer {
 	@Override
 	public boolean isAlive() {
 		return isAlive;
+	}
+
+	public void prepareToShutDown(){
+
+		LOG.info("Preparing Nvmf-Storage server for shutdown");
+
+		this.isAlive = false;
+
+		// stop jnvmf controller
+		try {
+			this.controller.free();
+		} catch(Exception e) {
+			e.printStackTrace();
+		}
 	}
 }

--- a/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageServer.java
+++ b/storage-rdma/src/main/java/org/apache/crail/storage/rdma/RdmaStorageServer.java
@@ -64,7 +64,7 @@ public class RdmaStorageServer implements Runnable, StorageServer {
 			LOG.info("Configured network interface " + RdmaConstants.STORAGE_RDMA_INTERFACE + " cannot be found..exiting!!!");
 			return;
 		}
-		this.datanodeGroup = new RdmaActiveEndpointGroup<RdmaStorageServerEndpoint>(-1, false, 1, 1, 1);
+		this.datanodeGroup = new RdmaActiveEndpointGroup<RdmaStorageServerEndpoint>(1000, false, 1, 1, 1);
 		this.datanodeServerEndpoint = datanodeGroup.createServerEndpoint();
 		datanodeGroup.init(new RdmaStorageEndpointFactory(datanodeGroup, this));
 		datanodeServerEndpoint.bind(serverAddr, RdmaConstants.STORAGE_RDMA_BACKLOG);
@@ -130,9 +130,12 @@ public class RdmaStorageServer implements Runnable, StorageServer {
 				LOG.info("accepting client connection, conncount " + allEndpoints.size());
 			}			
 		} catch(Exception e){
-			e.printStackTrace();
+			// if StorageServer is still marked as running output stacktrace
+			// otherwise this is expected behaviour
+			if(this.isAlive) {
+				e.printStackTrace();
+			}
 		}
-		this.isAlive = false;
 	}
 
 	@Override
@@ -143,5 +146,30 @@ public class RdmaStorageServer implements Runnable, StorageServer {
 	@Override
 	public boolean isAlive() {
 		return isAlive;
+	}
+
+	public void prepareToShutDown(){
+
+		LOG.info("Preparing RDMA-Storage server for shutdown");
+		this.isAlive = false;
+
+		try {
+
+			// close all open clientEndpoints
+			for(RdmaEndpoint endpoint : this.allEndpoints.values()) {
+				this.close(endpoint);
+			}
+
+			// close datanodeServerEndpoint and notify to exit blocking accept
+			this.datanodeServerEndpoint.close();
+			synchronized(this.datanodeServerEndpoint) {this.datanodeServerEndpoint.notifyAll();}
+
+			// close datanodeGroup
+			this.datanodeGroup.close();
+
+		} catch(Exception e) {
+			e.printStackTrace();
+		}
+
 	}
 }

--- a/storage/src/main/java/org/apache/crail/storage/StorageServer.java
+++ b/storage/src/main/java/org/apache/crail/storage/StorageServer.java
@@ -36,6 +36,7 @@ import org.apache.crail.conf.Configurable;
 import org.apache.crail.conf.CrailConfiguration;
 import org.apache.crail.conf.CrailConstants;
 import org.apache.crail.metadata.DataNodeStatistics;
+import org.apache.crail.metadata.DataNodeStatus;
 import org.apache.crail.rpc.RpcClient;
 import org.apache.crail.rpc.RpcConnection;
 import org.apache.crail.rpc.RpcDispatcher;
@@ -177,7 +178,7 @@ public interface StorageServer extends Configurable, Runnable {
 			DataNodeStatistics stats = storageRpc.getDataNode();
 			long newCount = stats.getFreeBlockCount();
 			long serviceId = stats.getServiceId();
-			short status = stats.getStatus();
+			short status = stats.getStatus().getStatus();
 			
 			long oldCount = 0;
 			if (blockCount.containsKey(serviceId)){
@@ -194,7 +195,7 @@ public interface StorageServer extends Configurable, Runnable {
 	}
 
 	public static void processStatus(StorageServer server, RpcConnection rpc, Thread thread, short status) throws Exception {
-		if (status == RpcErrors.ERR_DATANODE_STOP) {
+		if (status == DataNodeStatus.STATUS_DATANODE_STOP) {
 			server.prepareToShutDown();
 			rpc.close();
 			

--- a/storage/src/main/java/org/apache/crail/storage/StorageServer.java
+++ b/storage/src/main/java/org/apache/crail/storage/StorageServer.java
@@ -39,12 +39,14 @@ import org.apache.crail.metadata.DataNodeStatistics;
 import org.apache.crail.rpc.RpcClient;
 import org.apache.crail.rpc.RpcConnection;
 import org.apache.crail.rpc.RpcDispatcher;
+import org.apache.crail.rpc.RpcErrors;
 import org.apache.crail.utils.CrailUtils;
 import org.slf4j.Logger;
 
 public interface StorageServer extends Configurable, Runnable {
 	public abstract StorageResource allocateResource() throws Exception;
 	public abstract boolean isAlive();
+	public abstract void prepareToShutDown();
 	public abstract InetSocketAddress getAddress();
 	
 	public static void main(String[] args) throws Exception {
@@ -175,6 +177,7 @@ public interface StorageServer extends Configurable, Runnable {
 			DataNodeStatistics stats = storageRpc.getDataNode();
 			long newCount = stats.getFreeBlockCount();
 			long serviceId = stats.getServiceId();
+			short status = stats.getStatus();
 			
 			long oldCount = 0;
 			if (blockCount.containsKey(serviceId)){
@@ -185,7 +188,22 @@ public interface StorageServer extends Configurable, Runnable {
 			sumCount += diffCount;			
 			
 			LOG.info("datanode statistics, freeBlocks " + sumCount);
+			processStatus(server, rpcConnection, thread, status);
 			Thread.sleep(CrailConstants.STORAGE_KEEPALIVE*1000);
 		}			
+	}
+
+	public static void processStatus(StorageServer server, RpcConnection rpc, Thread thread, short status) throws Exception {
+		if (status == RpcErrors.ERR_DATANODE_STOP) {
+			server.prepareToShutDown();
+			rpc.close();
+			
+			// interrupt sleeping thread
+			try {
+				thread.interrupt();
+			} catch(Exception e) {
+				e.printStackTrace();
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR is the second of three planned PRs for implementing resource elasticity within Crail. More specifically, the goal is to allow to automatically and dynamically adapt the number of running datanodes based on different possible parameters (e.g. resource consumption, available storage capacities, ...). This requires support for starting and terminating running datanodes automatically. This functionality will be implemented mostly within the Crail namenode. Therefore, the Crail namenode will not only maintain information on the current state of the datanodes and the deployment but will also start or terminate datanodes as required. For deciding how to adjust the number of datanodes  based on the current state observed in the Crail namenode so-called _policies_ are used. 

The following changes will be included within the seperate PRs:

1) The first PR implements a new RPC (for both darpc and narpc) that allows to specify a datanode (using IP-address and port number) that should be shutdown.

2) In this second PR the actual mechanism for shutting down a datanode is covered. This includes checking that a datanode can be removed safely (i.e. the datanode does not store any remaining data), otherwise it will only be scheduled for removal. This PR also handles the datanode termination for all of the three available storage layers. 

3) The third PR implements a simple example policy for implementing elasticity based on the system's storage consumption.