### PR TITLE
Resource Elasticity [3/3]

### DIFF
--- a/client/src/main/java/org/apache/crail/conf/CrailConstants.java
+++ b/client/src/main/java/org/apache/crail/conf/CrailConstants.java
@@ -119,11 +119,6 @@ public class CrailConstants {
 	public static int STORAGE_KEEPALIVE = 2;
 
 	// elasticstore
-	public static final String ELASTIC_NAMENODE_RPC_SERVICE = "org.apache.crail.namenode.ElasticNameNodeService";
-
-	public static final String ELASTICSTORE_KEY = "crail.elasticstore";
-	public static boolean ELASTICSTORE = false;
-
 	public static final String ELASTICSTORE_SCALEUP_KEY = "crail.elasticstore.scaleup";
 	public static double ELASTICSTORE_SCALEUP = 0.4;
 
@@ -215,6 +210,9 @@ public class CrailConstants {
 		if (conf.get(NAMENODE_RPC_TYPE_KEY) != null) {
 			NAMENODE_RPC_TYPE = conf.get(NAMENODE_RPC_TYPE_KEY);
 		}
+		if(conf.get(NAMENODE_RPC_SERVICE_KEY) != null) {
+			NAMENODE_RPC_SERVICE = conf.get(NAMENODE_RPC_SERVICE_KEY);
+		}
 		if (conf.get(NAMENODE_LOG_KEY) != null) {
 			NAMENODE_LOG = conf.get(NAMENODE_LOG_KEY);
 		}
@@ -236,9 +234,6 @@ public class CrailConstants {
 		}
 
 		//elasticstore
-		if(conf.get(ELASTICSTORE_KEY) != null) {
-			ELASTICSTORE = Boolean.parseBoolean(conf.get(ELASTICSTORE_KEY));
-		}
 		if (conf.get(ELASTICSTORE_SCALEUP_KEY) != null) {
 			ELASTICSTORE_SCALEUP = Double.parseDouble(conf.get(ELASTICSTORE_SCALEUP_KEY));
 		}
@@ -287,12 +282,12 @@ public class CrailConstants {
 		LOG.info(NAMENODE_BLOCKSELECTION_KEY + " " + NAMENODE_BLOCKSELECTION);
 		LOG.info(NAMENODE_FILEBLOCKS_KEY + " " + NAMENODE_FILEBLOCKS);
 		LOG.info(NAMENODE_RPC_TYPE_KEY + " " + NAMENODE_RPC_TYPE);
+		LOG.info(NAMENODE_RPC_SERVICE_KEY + " " + NAMENODE_RPC_SERVICE);
 		LOG.info(NAMENODE_LOG_KEY + " " + NAMENODE_LOG);
 		LOG.info(STORAGE_TYPES_KEY + " " + STORAGE_TYPES);
 		LOG.info(STORAGE_CLASSES_KEY + " " + STORAGE_CLASSES);
 		LOG.info(STORAGE_ROOTCLASS_KEY + " " + STORAGE_ROOTCLASS);
 		LOG.info(STORAGE_KEEPALIVE_KEY + " " + STORAGE_KEEPALIVE);
-		LOG.info(ELASTICSTORE_KEY + " " + ELASTICSTORE);
 		LOG.info(ELASTICSTORE_SCALEUP_KEY + " " + ELASTICSTORE_SCALEUP);
 		LOG.info(ELASTICSTORE_SCALEDOWN_KEY + " " + ELASTICSTORE_SCALEDOWN);
 		LOG.info(ELASTICSTORE_MAXNODES_KEY + " " + ELASTICSTORE_MAXNODES);

--- a/client/src/main/java/org/apache/crail/conf/CrailConstants.java
+++ b/client/src/main/java/org/apache/crail/conf/CrailConstants.java
@@ -118,6 +118,30 @@ public class CrailConstants {
 	public static final String STORAGE_KEEPALIVE_KEY = "crail.storage.keepalive";
 	public static int STORAGE_KEEPALIVE = 2;
 
+	// elasticstore
+	public static final String ELASTIC_NAMENODE_RPC_SERVICE = "org.apache.crail.namenode.ElasticNameNodeService";
+
+	public static final String ELASTICSTORE_KEY = "crail.elasticstore";
+	public static boolean ELASTICSTORE = false;
+
+	public static final String ELASTICSTORE_SCALEUP_KEY = "crail.elasticstore.scaleup";
+	public static double ELASTICSTORE_SCALEUP = 0.4;
+
+	public static final String ELASTICSTORE_SCALEDOWN_KEY = "crail.elasticstore.scaledown";
+	public static double ELASTICSTORE_SCALEDOWN = 0.1;
+
+	public static final String ELASTICSTORE_MINNODES_KEY = "crail.elasticstore.minnodes";
+	public static int ELASTICSTORE_MINNODES = 1;
+	
+	public static final String ELASTICSTORE_MAXNODES_KEY = "crail.elasticstore.maxnodes";
+	public static int ELASTICSTORE_MAXNODES = 10;
+
+	public static final String ELASTICSTORE_POLICYRUNNER_INTERVAL_KEY = "crail.elasticstore.policyrunner.interval";
+	public static int ELASTICSTORE_POLICYRUNNER_INTERVAL = 1000;
+
+	public static final String ELASTICSTORE_LOGGING_KEY = "crail.elasticstore.logging";
+	public static boolean ELASTICSTORE_LOGGING = false;
+
 	public static void updateConstants(CrailConfiguration conf){
 		//general
 		if (conf.get(DIRECTORY_DEPTH_KEY) != null) {
@@ -210,6 +234,32 @@ public class CrailConstants {
 		if (conf.get(STORAGE_KEEPALIVE_KEY) != null) {
 			STORAGE_KEEPALIVE = Integer.parseInt(conf.get(STORAGE_KEEPALIVE_KEY));
 		}
+
+		//elasticstore
+		if(conf.get(ELASTICSTORE_KEY) != null) {
+			ELASTICSTORE = Boolean.parseBoolean(conf.get(ELASTICSTORE_KEY));
+		}
+		if (conf.get(ELASTICSTORE_SCALEUP_KEY) != null) {
+			ELASTICSTORE_SCALEUP = Double.parseDouble(conf.get(ELASTICSTORE_SCALEUP_KEY));
+		}
+
+		if (conf.get(ELASTICSTORE_SCALEDOWN_KEY) != null) {
+			ELASTICSTORE_SCALEDOWN = Double.parseDouble(conf.get(ELASTICSTORE_SCALEDOWN_KEY));
+		}
+
+		if (conf.get(ELASTICSTORE_MINNODES_KEY) != null) {
+			ELASTICSTORE_MINNODES = Integer.parseInt(conf.get(ELASTICSTORE_MINNODES_KEY));
+		}
+
+		if (conf.get(ELASTICSTORE_MAXNODES_KEY) != null) {
+			ELASTICSTORE_MAXNODES = Integer.parseInt(conf.get(ELASTICSTORE_MAXNODES_KEY));
+		}
+		if (conf.get(ELASTICSTORE_POLICYRUNNER_INTERVAL_KEY) != null) {
+			ELASTICSTORE_POLICYRUNNER_INTERVAL = Integer.parseInt(conf.get(ELASTICSTORE_POLICYRUNNER_INTERVAL_KEY));
+		}
+		if(conf.get(ELASTICSTORE_LOGGING_KEY) != null) {
+			ELASTICSTORE_LOGGING = Boolean.parseBoolean(conf.get(ELASTICSTORE_LOGGING_KEY));
+		}
 	}
 
 	public static void printConf(){
@@ -242,6 +292,13 @@ public class CrailConstants {
 		LOG.info(STORAGE_CLASSES_KEY + " " + STORAGE_CLASSES);
 		LOG.info(STORAGE_ROOTCLASS_KEY + " " + STORAGE_ROOTCLASS);
 		LOG.info(STORAGE_KEEPALIVE_KEY + " " + STORAGE_KEEPALIVE);
+		LOG.info(ELASTICSTORE_KEY + " " + ELASTICSTORE);
+		LOG.info(ELASTICSTORE_SCALEUP_KEY + " " + ELASTICSTORE_SCALEUP);
+		LOG.info(ELASTICSTORE_SCALEDOWN_KEY + " " + ELASTICSTORE_SCALEDOWN);
+		LOG.info(ELASTICSTORE_MAXNODES_KEY + " " + ELASTICSTORE_MAXNODES);
+		LOG.info(ELASTICSTORE_MINNODES_KEY + " " + ELASTICSTORE_MINNODES);
+		LOG.info(ELASTICSTORE_POLICYRUNNER_INTERVAL_KEY + " " + ELASTICSTORE_POLICYRUNNER_INTERVAL);
+		LOG.info(ELASTICSTORE_LOGGING_KEY + " " + ELASTICSTORE_LOGGING);
 	}
 
 	public static void verify() throws IOException {

--- a/client/src/main/java/org/apache/crail/conf/CrailConstants.java
+++ b/client/src/main/java/org/apache/crail/conf/CrailConstants.java
@@ -210,7 +210,7 @@ public class CrailConstants {
 		if (conf.get(NAMENODE_RPC_TYPE_KEY) != null) {
 			NAMENODE_RPC_TYPE = conf.get(NAMENODE_RPC_TYPE_KEY);
 		}
-		if(conf.get(NAMENODE_RPC_SERVICE_KEY) != null) {
+		if (conf.get(NAMENODE_RPC_SERVICE_KEY) != null) {
 			NAMENODE_RPC_SERVICE = conf.get(NAMENODE_RPC_SERVICE_KEY);
 		}
 		if (conf.get(NAMENODE_LOG_KEY) != null) {
@@ -252,7 +252,7 @@ public class CrailConstants {
 		if (conf.get(ELASTICSTORE_POLICYRUNNER_INTERVAL_KEY) != null) {
 			ELASTICSTORE_POLICYRUNNER_INTERVAL = Integer.parseInt(conf.get(ELASTICSTORE_POLICYRUNNER_INTERVAL_KEY));
 		}
-		if(conf.get(ELASTICSTORE_LOGGING_KEY) != null) {
+		if (conf.get(ELASTICSTORE_LOGGING_KEY) != null) {
 			ELASTICSTORE_LOGGING = Boolean.parseBoolean(conf.get(ELASTICSTORE_LOGGING_KEY));
 		}
 	}

--- a/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
@@ -107,12 +107,12 @@ public class BlockStore {
 		return RpcErrors.ERR_DATANODE_NOT_REGISTERED;
 	}
 
-	public double getStorageUsage() throws Exception {
+	public double getStorageUsedPercentage() throws Exception {
 		long total = 0;
 		long free = 0;
 		for(StorageClass storageClass : storageClasses) {
-			total += storageClass.getTotalCapacity();
-			free += storageClass.getFreeCapacity();
+			total += storageClass.getTotalBlockCount();
+			free += storageClass.getFreeBlockCount();
 		}
 
 		// if there is no available capacity (i.e. total number of available blocks is 0),
@@ -126,31 +126,31 @@ public class BlockStore {
 
 	}
 
-	public int getBlockUsage() throws Exception {
+	public long getNumberOfBlocksUsed() throws Exception {
 		int total = 0;
 
 		for(StorageClass storageClass: storageClasses) {
-			total += (storageClass.getTotalCapacity() - storageClass.getFreeCapacity());
+			total += (storageClass.getTotalBlockCount() - storageClass.getFreeBlockCount());
 		}
 
 		return total;
 	}
 
-	public int getBlockCapacity() throws Exception {
+	public long getNumberOfBlocks() throws Exception {
 		int total = 0;
 
 		for(StorageClass storageClass: storageClasses) {
-			total += storageClass.getTotalCapacity();
+			total += storageClass.getTotalBlockCount();
 		}
 
 		return total;
 	}
 
-	public int getNumberDatanodes() {
+	public int getNumberOfRunningDatanodes() {
 		int total = 0;
 
 		for(StorageClass storageClass : storageClasses) {
-			total += storageClass.getRunningDatanodes();
+			total += storageClass.getNumberOfRunningDatanodes();
 		}
 
 		return total;
@@ -303,17 +303,17 @@ class StorageClass {
 
 	//---------------
 
-	public long getTotalCapacity() {
+	public long getTotalBlockCount() {
 		long capacity = 0;
 
 		for(DataNodeBlocks datanode : membership.values()) {
-			capacity += datanode.getMaxBlockCount();
+			capacity += datanode.getTotalNumberOfBlocks();
 		}
 
 		return capacity;
 	}
 
-	public long getFreeCapacity() {
+	public long getFreeBlockCount() {
 		long capacity = 0;
 
 		for(DataNodeBlocks datanode : membership.values()) {
@@ -327,7 +327,7 @@ class StorageClass {
 		return this.membership.values();
 	}
 
-	public int getRunningDatanodes() {
+	public int getNumberOfRunningDatanodes() {
 		return this.membership.size();
 	}
 

--- a/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/BlockStore.java
@@ -97,7 +97,7 @@ public class BlockStore {
 		// nevertheless target only one running datanode instance.
 		// Therefore we can iterate over all storageClasses to check whether
 		// the requested datanode is part of one of the storageClasses.
-		for(StorageClass storageClass : storageClasses) {
+		for (StorageClass storageClass : storageClasses) {
 			if (storageClass.getDataNode(dn) != null) {
 				return storageClass.prepareForRemovalDatanode(dn);
 			}
@@ -110,14 +110,14 @@ public class BlockStore {
 	public double getStorageUsedPercentage() throws Exception {
 		long total = 0;
 		long free = 0;
-		for(StorageClass storageClass : storageClasses) {
+		for (StorageClass storageClass : storageClasses) {
 			total += storageClass.getTotalBlockCount();
 			free += storageClass.getFreeBlockCount();
 		}
 
 		// if there is no available capacity (i.e. total number of available blocks is 0),
 		// return 1.0 which tells that all storage is used
-		if(total != 0) {
+		if (total != 0) {
 			double available = (double) free / (double) total;
 			return 1.0 - available;
 		} else {
@@ -129,7 +129,7 @@ public class BlockStore {
 	public long getNumberOfBlocksUsed() throws Exception {
 		int total = 0;
 
-		for(StorageClass storageClass: storageClasses) {
+		for (StorageClass storageClass: storageClasses) {
 			total += (storageClass.getTotalBlockCount() - storageClass.getFreeBlockCount());
 		}
 
@@ -139,7 +139,7 @@ public class BlockStore {
 	public long getNumberOfBlocks() throws Exception {
 		int total = 0;
 
-		for(StorageClass storageClass: storageClasses) {
+		for (StorageClass storageClass: storageClasses) {
 			total += storageClass.getTotalBlockCount();
 		}
 
@@ -149,7 +149,7 @@ public class BlockStore {
 	public int getNumberOfRunningDatanodes() {
 		int total = 0;
 
-		for(StorageClass storageClass : storageClasses) {
+		for (StorageClass storageClass : storageClasses) {
 			total += storageClass.getNumberOfRunningDatanodes();
 		}
 
@@ -159,14 +159,14 @@ public class BlockStore {
 	public DataNodeBlocks identifyRemoveCandidate() {
 
 		ArrayList<DataNodeBlocks> dataNodeBlocks = new ArrayList<DataNodeBlocks>();
-		for(StorageClass storageClass : storageClasses) {
+		for (StorageClass storageClass : storageClasses) {
 			dataNodeBlocks.addAll(storageClass.getDataNodeBlocks());
 		}
 
 		// sort all datanodes by increasing numbers of available datablocks
 		Collections.sort(dataNodeBlocks, new Comparator<DataNodeBlocks>() {
 			public int compare(DataNodeBlocks d1, DataNodeBlocks d2) {
-				if(d1.getBlockCount() < d2.getBlockCount()) {
+				if (d1.getBlockCount() < d2.getBlockCount()) {
 					return 1;
 				} else if (d1.getBlockCount() > d2.getBlockCount()) {
 					return -1;
@@ -175,8 +175,8 @@ public class BlockStore {
 		});
 
 		// iterate over datanodes and return first datanode which is not already scheduled for removal
-		for(DataNodeBlocks candidate: dataNodeBlocks) {
-			if(!candidate.isScheduleForRemoval()) {
+		for (DataNodeBlocks candidate: dataNodeBlocks) {
+			if (!candidate.isScheduleForRemoval()) {
 				return candidate;
 			}
 		}
@@ -306,7 +306,7 @@ class StorageClass {
 	public long getTotalBlockCount() {
 		long capacity = 0;
 
-		for(DataNodeBlocks datanode : membership.values()) {
+		for (DataNodeBlocks datanode : membership.values()) {
 			capacity += datanode.getTotalNumberOfBlocks();
 		}
 
@@ -316,7 +316,7 @@ class StorageClass {
 	public long getFreeBlockCount() {
 		long capacity = 0;
 
-		for(DataNodeBlocks datanode : membership.values()) {
+		for (DataNodeBlocks datanode : membership.values()) {
 			capacity += datanode.getBlockCount();
 		}
 

--- a/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
@@ -86,6 +86,10 @@ public class DataNodeBlocks extends DataNodeInfo {
 		return this.scheduleForRemoval;
 	}
 
+	public long getMaxBlockCount() {
+		return this.maxBlockCount;
+	}
+
 	public int getBlockCount() {
 		return this.freeBlocks.size();
 	}

--- a/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/DataNodeBlocks.java
@@ -86,7 +86,7 @@ public class DataNodeBlocks extends DataNodeInfo {
 		return this.scheduleForRemoval;
 	}
 
-	public long getMaxBlockCount() {
+	public long getTotalNumberOfBlocks() {
 		return this.maxBlockCount;
 	}
 

--- a/namenode/src/main/java/org/apache/crail/namenode/ElasticNameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/ElasticNameNodeService.java
@@ -1,0 +1,19 @@
+package org.apache.crail.namenode;
+
+import java.io.IOException;
+
+import org.apache.crail.conf.CrailConstants;
+
+public class ElasticNameNodeService extends NameNodeService {
+
+    PolicyRunner policyRunner;
+
+    public ElasticNameNodeService() throws IOException {
+
+        this.policyRunner = new FreeCapacityPolicy(this,
+                CrailConstants.ELASTICSTORE_SCALEUP,
+                CrailConstants.ELASTICSTORE_SCALEDOWN,
+                CrailConstants.ELASTICSTORE_MINNODES,
+                CrailConstants.ELASTICSTORE_MAXNODES);
+    }
+}

--- a/namenode/src/main/java/org/apache/crail/namenode/FreeCapacityPolicy.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/FreeCapacityPolicy.java
@@ -32,25 +32,25 @@ public class FreeCapacityPolicy extends PolicyRunner {
             // log current usage information
             double usage = this.service.getStorageUsedPercentage();
 
-            if(CrailConstants.ELASTICSTORE_LOGGING) {
+            if (CrailConstants.ELASTICSTORE_LOGGING) {
                 LOG.info("Current block usage: " + this.service.getNumberOfBlocksUsed() + "/" + this.service.getNumberOfBlocks());
                 LOG.info("Current storage usage: " + 100*usage + "%");
                 LOG.info("Current number of datanodes: " + this.datanodes);
             }
 
             // check whether datanode launch/terminate operation finished
-            if(!this.updated && this.lastCapacity != this.service.getNumberOfBlocks()) {
+            if (!this.updated && this.lastCapacity != this.service.getNumberOfBlocks()) {
                 this.updated = true;
             }
 
             // check whether scaling up or down is possible
-            if(this.updated) {
-                if(usage < scaleDown && this.datanodes > minDataNodes) {
+            if (this.updated) {
+                if (usage < scaleDown && this.datanodes > minDataNodes) {
                     LOG.info("Scale down detected");
     
                     DataNodeBlocks removeCandidate = this.service.identifyRemoveCandidate();
     
-                    if(removeCandidate != null) {
+                    if (removeCandidate != null) {
                         this.lastCapacity = this.service.getNumberOfBlocks();
                         this.updated = false;
                         this.service.prepareDataNodeForRemoval(removeCandidate);
@@ -58,7 +58,7 @@ public class FreeCapacityPolicy extends PolicyRunner {
                     }
                 }
     
-                if(usage > this.scaleUp && this.datanodes < maxDataNodes) {
+                if (usage > this.scaleUp && this.datanodes < maxDataNodes) {
                     LOG.info("Scale up detected");
                     this.lastCapacity = this.service.getNumberOfBlocks();
                     this.updated = false;

--- a/namenode/src/main/java/org/apache/crail/namenode/FreeCapacityPolicy.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/FreeCapacityPolicy.java
@@ -1,0 +1,75 @@
+package org.apache.crail.namenode;
+
+import org.apache.crail.conf.CrailConstants;
+import org.apache.crail.rpc.RpcNameNodeService;
+
+public class FreeCapacityPolicy extends PolicyRunner {
+
+    double scaleUp;
+    double scaleDown;
+    int minDataNodes;
+    int maxDataNodes;
+    int datanodes; // maintains the desired number of datanodes (i.e. a datanode might be still starting / terminating)
+    boolean updated; // shows whether a launch/terminate datanode operation returned
+    int lastCapacity; // maintains the capacity that was available when the launch/terminate datanode operation was issued
+
+    FreeCapacityPolicy(RpcNameNodeService service, double scaleUp, double scaleDown, int minDataNodes, int maxDataNodes) {
+        super(service);
+        this.scaleUp = scaleUp;
+        this.scaleDown = scaleDown;
+        this.minDataNodes = minDataNodes;
+        this.maxDataNodes = maxDataNodes;
+        this.datanodes = 0;
+        this.updated = true;
+        this.lastCapacity = 0;
+    }
+
+    @Override
+    public void checkPolicy() {
+
+        try {
+
+            // log current usage information
+            double usage = this.service.getStorageUsage();
+
+            if(CrailConstants.ELASTICSTORE_LOGGING) {
+                LOG.info("Current block usage: " + this.service.getBlockUsage() + "/" + this.service.getBlockCapacity());
+                LOG.info("Current storage usage: " + 100*usage + "%");
+                LOG.info("Current number of datanodes: " + this.datanodes);
+            }
+
+            // check whether datanode launch/terminate operation finished
+            if(!this.updated && this.lastCapacity != this.service.getBlockCapacity()) {
+                this.updated = true;
+            }
+
+            // check whether scaling up or down is possible
+            if(this.updated) {
+                if(usage < scaleDown && this.datanodes > minDataNodes) {
+                    LOG.info("Scale down detected");
+    
+                    DataNodeBlocks removeCandidate = this.service.identifyRemoveCandidate();
+    
+                    if(removeCandidate != null) {
+                        this.lastCapacity = this.service.getBlockCapacity();
+                        this.updated = false;
+                        this.service.prepareDataNodeForRemoval(removeCandidate);
+                        this.datanodes--;
+                    }
+                }
+    
+                if(usage > this.scaleUp && this.datanodes < maxDataNodes) {
+                    LOG.info("Scale up detected");
+                    this.lastCapacity = this.service.getBlockCapacity();
+                    this.updated = false;
+                    launchDatanode();
+                    this.datanodes++;
+                }
+            }
+
+
+        } catch (Exception e) {
+            LOG.error("Unable to retrieve storage usage information");
+        }
+    }
+}

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNode.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNode.java
@@ -83,12 +83,7 @@ public class NameNode {
 		CrailConstants.verify();
 
 		RpcNameNodeService service;
-
-		if(CrailConstants.ELASTICSTORE) {
-			service = RpcNameNodeService.createInstance(CrailConstants.ELASTIC_NAMENODE_RPC_SERVICE);
-		} else {
-			service = RpcNameNodeService.createInstance(CrailConstants.NAMENODE_RPC_SERVICE);
-		}
+		service = RpcNameNodeService.createInstance(CrailConstants.NAMENODE_RPC_SERVICE);
 
 		if (!CrailConstants.NAMENODE_LOG.isEmpty()){
 			LogDispatcher logDispatcher = new LogDispatcher(service);

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNode.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNode.java
@@ -81,8 +81,15 @@ public class NameNode {
 		CrailConstants.NAMENODE_ADDRESS = namenode + "?id=" + serviceId + "&size=" + serviceSize;
 		CrailConstants.printConf();
 		CrailConstants.verify();
-		
-		RpcNameNodeService service = RpcNameNodeService.createInstance(CrailConstants.NAMENODE_RPC_SERVICE);
+
+		RpcNameNodeService service;
+
+		if(CrailConstants.ELASTICSTORE) {
+			service = RpcNameNodeService.createInstance(CrailConstants.ELASTIC_NAMENODE_RPC_SERVICE);
+		} else {
+			service = RpcNameNodeService.createInstance(CrailConstants.NAMENODE_RPC_SERVICE);
+		}
+
 		if (!CrailConstants.NAMENODE_LOG.isEmpty()){
 			LogDispatcher logDispatcher = new LogDispatcher(service);
 			service = logDispatcher;

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNode.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNode.java
@@ -81,10 +81,8 @@ public class NameNode {
 		CrailConstants.NAMENODE_ADDRESS = namenode + "?id=" + serviceId + "&size=" + serviceSize;
 		CrailConstants.printConf();
 		CrailConstants.verify();
-
-		RpcNameNodeService service;
-		service = RpcNameNodeService.createInstance(CrailConstants.NAMENODE_RPC_SERVICE);
-
+		
+		RpcNameNodeService service = RpcNameNodeService.createInstance(CrailConstants.NAMENODE_RPC_SERVICE);
 		if (!CrailConstants.NAMENODE_LOG.isEmpty()){
 			LogDispatcher logDispatcher = new LogDispatcher(service);
 			service = logDispatcher;

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -552,20 +552,20 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		return RpcErrors.ERR_OK;
 	}
 
-	public double getStorageUsage() throws Exception {
-		return this.blockStore.getStorageUsage();
+	public double getStorageUsedPercentage() throws Exception {
+		return this.blockStore.getStorageUsedPercentage();
 	}
 
-	public int getBlockUsage() throws Exception {
-		return this.blockStore.getBlockUsage();
+	public long getNumberOfBlocksUsed() throws Exception {
+		return this.blockStore.getNumberOfBlocksUsed();
 	}
 
-	public int getBlockCapacity() throws Exception {
-		return this.blockStore.getBlockCapacity();
+	public long getNumberOfBlocks() throws Exception {
+		return this.blockStore.getNumberOfBlocks();
 	}
 
-	public int getNumberDatanodes() {
-		return this.blockStore.getNumberDatanodes();
+	public int getNumberOfRunningDatanodes() {
+		return this.blockStore.getNumberOfRunningDatanodes();
 	}
 
 	public DataNodeBlocks identifyRemoveCandidate() {

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -434,7 +434,7 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		if (!RpcProtocol.verifyProtocol(RpcProtocol.CMD_SET_BLOCK, request, response)){
 			return RpcErrors.ERR_PROTOCOL_MISMATCH;
 		}		
-
+		
 		//get params
 		BlockInfo region = new BlockInfo();
 		region.setBlockInfo(request.getBlockInfo());

--- a/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/NameNodeService.java
@@ -434,7 +434,7 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		if (!RpcProtocol.verifyProtocol(RpcProtocol.CMD_SET_BLOCK, request, response)){
 			return RpcErrors.ERR_PROTOCOL_MISMATCH;
 		}		
-		
+
 		//get params
 		BlockInfo region = new BlockInfo();
 		region.setBlockInfo(request.getBlockInfo());
@@ -550,6 +550,26 @@ public class NameNodeService implements RpcNameNodeService, Sequencer {
 		response.setBlockInfo(block);
 		
 		return RpcErrors.ERR_OK;
+	}
+
+	public double getStorageUsage() throws Exception {
+		return this.blockStore.getStorageUsage();
+	}
+
+	public int getBlockUsage() throws Exception {
+		return this.blockStore.getBlockUsage();
+	}
+
+	public int getBlockCapacity() throws Exception {
+		return this.blockStore.getBlockCapacity();
+	}
+
+	public int getNumberDatanodes() {
+		return this.blockStore.getNumberDatanodes();
+	}
+
+	public DataNodeBlocks identifyRemoveCandidate() {
+		return  this.blockStore.identifyRemoveCandidate();
 	}
 
 	//------------------------

--- a/namenode/src/main/java/org/apache/crail/namenode/PolicyRunner.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/PolicyRunner.java
@@ -21,7 +21,7 @@ public abstract class PolicyRunner implements Runnable {
 
     public void run() {
 
-        while(true) {
+        while (true) {
             checkPolicy();
 
             try {

--- a/namenode/src/main/java/org/apache/crail/namenode/PolicyRunner.java
+++ b/namenode/src/main/java/org/apache/crail/namenode/PolicyRunner.java
@@ -1,0 +1,51 @@
+package org.apache.crail.namenode;
+
+import org.apache.crail.conf.CrailConstants;
+import org.apache.crail.rpc.RpcNameNodeService;
+import org.apache.crail.utils.CrailUtils;
+import org.slf4j.Logger;
+
+public abstract class PolicyRunner implements Runnable {
+
+    static final Logger LOG = CrailUtils.getLogger();
+    NameNodeService service;
+    int instances = 0;
+
+    PolicyRunner(RpcNameNodeService service){
+        this.service = (NameNodeService) service;
+        Thread runner = new Thread(this);
+        runner.start();
+    }
+
+    public abstract void checkPolicy();
+
+    public void run() {
+
+        while(true) {
+            checkPolicy();
+
+            try {
+                Thread.sleep(CrailConstants.ELASTICSTORE_POLICYRUNNER_INTERVAL);
+            } catch(Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+    }
+
+    public void launchDatanode() {
+
+        try {
+            String port = Integer.toString(50020+this.instances);
+            Process p = new ProcessBuilder(System.getenv("CRAIL_HOME") + "/bin/crail", "datanode", "--",  "-p" + port).start();
+
+            LOG.info("Launched new datanode instance");
+            this.instances++;
+
+        } catch(Exception e) {
+            LOG.error("Unable to launch datanode");
+            e.printStackTrace();
+        }
+
+    }
+}


### PR DESCRIPTION
This PR is the third of three planned PRs for implementing resource elasticity within Crail. More specifically, the goal is to allow to automatically and dynamically adapt the number of running datanodes based on different possible parameters (e.g. resource consumption, available storage capacities, ...). This requires support for starting and terminating running datanodes automatically. This functionality will be implemented mostly within the Crail namenode. Therefore, the Crail namenode will not only maintain information on the current state of the datanodes and the deployment but will also start or terminate datanodes as required. For deciding how to adjust the number of datanodes  based on the current state observed in the Crail namenode so-called _policies_ are used. 

The following changes will be included within the seperate PRs:

1) This first PR implements a new RPC (for both darpc and narpc) that allows to specify a datanode (using IP-address and port number) that should be shutdown.
2) The seconds PR will implement the actual mechanism for shutting down a datanode.

3) This third PR implements a simple policy for implementing elasticity based on the system's storage consumption. It introduces a new `ElasticNameNodeService` extending the existing `NameNodeService` which frequently evaluates the current storage utilization. When it exceeds a certain threshold this will make the namenode start new datanode(s). In case the utilization falls below a certain threshold the namenode tries to terminate unneeded datanodes using the shutdown mechanism. Parameters are configurable.